### PR TITLE
Add new fields to Elba output

### DIFF
--- a/doc/elba_config_example.json
+++ b/doc/elba_config_example.json
@@ -47,7 +47,7 @@
         "MSI_STATUS": "Negative",
         "PATHOLOGICAL_REVIEW": "Lots of immune cells",
         "PATIENT_ID": "Patient_001",
-	"PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in."
+        "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
         "PCT_v7_ABOVE_80x": 79.863,
         "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
         "SAMPLE_ID": "Sample_001",
@@ -58,6 +58,6 @@
         "TMB_PER_MB": 14.7,
         "TMB_PLOT": "/data/foo/bar/tmb.png",
         "TREATMENT_STATUS": "Naive",
-	"VAF_PLOT": "/data/foo/bar/vaf.png"
+        "VAF_PLOT": "/data/foo/bar/vaf.png"
     }
 }

--- a/doc/elba_config_example.json
+++ b/doc/elba_config_example.json
@@ -12,7 +12,8 @@
             "Gene Annotation": "Nullam nulla lacus, gravida id metus ut, fermentum.",
             "OncoKB": "NA",
             "Protein Change": "prot001",
-            "Variant / Total Reads": "38/185"
+            "Variant / Total Reads": "38/185",
+            "Whizbam URL": "http://example.com/whizbam/Gene001"
         },
         {
             "Allele Fraction (%)": 10,
@@ -26,7 +27,8 @@
             "Gene Annotation": "Etiam lobortis magna pellentesque, blandit nisi id, feugiat.",
             "OncoKB": "NA",
             "Protein Change": "prot002",
-            "Variant / Total Reads": "33/156"
+            "Variant / Total Reads": "33/156",
+            "Whizbam URL": "http://example.com/whizbam/Gene002"
         }
     ],
     "review_status": -1,
@@ -45,6 +47,7 @@
         "MSI_STATUS": "Negative",
         "PATHOLOGICAL_REVIEW": "Lots of immune cells",
         "PATIENT_ID": "Patient_001",
+	"PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in."
         "PCT_v7_ABOVE_80x": 79.863,
         "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
         "SAMPLE_ID": "Sample_001",

--- a/src/lib/djerba/data/input_schema.json
+++ b/src/lib/djerba/data/input_schema.json
@@ -148,7 +148,8 @@
 		    "FRACTION_GENOME_ALTERED": {"type": ["number", "null"]},
 		    "TMB_PLOT": {"type": ["string", "null"]},
 		    "VAF_PLOT": {"type": ["string", "null"]},
-		    "ETHNICITY": {"type": ["string", "null"]}
+		    "ETHNICITY": {"type": ["string", "null"]},
+		    "PATIENT_SUMMARY": {"type": ["string", "null"]}
 		},
 		"required": ["SAMPLE_ID"],
 		"uniqueItems": true

--- a/src/test/data/report_config_custom.json
+++ b/src/test/data/report_config_custom.json
@@ -4,12 +4,22 @@
             "datatype": "CUSTOM",
             "genetic_alteration_type": "CUSTOM_ANNOTATION",
             "input_files": {},
-	    "input_directory": "/dummy/directory/replaced/in/test",
+            "input_directory": "/dummy/directory/replaced/in/test",
             "metadata": {
-		"gene_headers": ["Gene", "Gene_metric_1", "Gene_metric_2", "Gene_metric_3"],
-		"gene_tsv": "custom_gene_annotation.tsv",
-		"sample_headers": ["SAMPLE_ID", "SAMPLE_METRIC_1", "SAMPLE_METRIC_2", "SAMPLE_METRIC_3"],
-		"sample_tsv": "custom_sample_annotation.tsv"
+                "gene_headers": [
+                    "Gene",
+                    "Gene_metric_1",
+                    "Gene_metric_2",
+                    "Gene_metric_3"
+                ],
+                "gene_tsv": "custom_gene_annotation.tsv",
+                "sample_headers": [
+                    "SAMPLE_ID",
+                    "SAMPLE_METRIC_1",
+                    "SAMPLE_METRIC_2",
+                    "SAMPLE_METRIC_3"
+                ],
+                "sample_tsv": "custom_sample_annotation.tsv"
             },
             "workflow_run_id": "jabberwocky_workflow_run_0001"
         }
@@ -28,7 +38,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
-	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
+            "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",
@@ -36,7 +46,7 @@
             "SEQUENZA_PLOIDY": null,
             "SEQUENZA_PURITY_FRACTION": null,
             "SEX": "Male",
-	    "TMB_PER_MB":  null,
+            "TMB_PER_MB": null,
             "TREATMENT_STATUS": "Naive"
         }
     ]

--- a/src/test/data/report_config_custom.json
+++ b/src/test/data/report_config_custom.json
@@ -28,6 +28,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
+	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",

--- a/src/test/data/report_config_custom_broken.json
+++ b/src/test/data/report_config_custom_broken.json
@@ -53,6 +53,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
+	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",

--- a/src/test/data/report_config_custom_broken.json
+++ b/src/test/data/report_config_custom_broken.json
@@ -29,12 +29,22 @@
             "datatype": "CUSTOM",
             "genetic_alteration_type": "CUSTOM_ANNOTATION",
             "input_files": {},
-	    "input_directory": "/dummy/directory/replaced/in/test",
+            "input_directory": "/dummy/directory/replaced/in/test",
             "metadata": {
-		"gene_headers": ["Gene", "Gene_metric_1", "Gene_metric_2", "Gene_metric_nonexistent"],
-		"gene_tsv": "custom_gene_annotation.tsv",
-		"sample_headers": ["SAMPLE_ID", "SAMPLE_METRIC_1", "SAMPLE_METRIC_2", "SAMPLE_METRIC_NONEXISTENT"],
-		"sample_tsv": "custom_sample_annotation.tsv"
+                "gene_headers": [
+                    "Gene",
+                    "Gene_metric_1",
+                    "Gene_metric_2",
+                    "Gene_metric_nonexistent"
+                ],
+                "gene_tsv": "custom_gene_annotation.tsv",
+                "sample_headers": [
+                    "SAMPLE_ID",
+                    "SAMPLE_METRIC_1",
+                    "SAMPLE_METRIC_2",
+                    "SAMPLE_METRIC_NONEXISTENT"
+                ],
+                "sample_tsv": "custom_sample_annotation.tsv"
             },
             "workflow_run_id": "jabberwocky_workflow_run_0001"
         }
@@ -53,7 +63,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
-	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
+            "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",
@@ -61,7 +71,7 @@
             "SEQUENZA_PLOIDY": null,
             "SEQUENZA_PURITY_FRACTION": null,
             "SEX": "Male",
-	    "TMB_PER_MB":  null,
+            "TMB_PER_MB": null,
             "TREATMENT_STATUS": "Naive"
         }
     ],

--- a/src/test/data/report_config_custom_with_nan.json
+++ b/src/test/data/report_config_custom_with_nan.json
@@ -53,6 +53,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
+	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",

--- a/src/test/data/report_config_custom_with_nan.json
+++ b/src/test/data/report_config_custom_with_nan.json
@@ -29,12 +29,22 @@
             "datatype": "CUSTOM",
             "genetic_alteration_type": "CUSTOM_ANNOTATION",
             "input_files": {},
-	    "input_directory": "/dummy/directory/replaced/in/test",
+            "input_directory": "/dummy/directory/replaced/in/test",
             "metadata": {
-		"gene_headers": ["Gene", "Gene_metric_1", "Gene_metric_2", "Gene_metric_3"],
-		"gene_tsv": "custom_gene_annotation_with_nan.tsv",
-		"sample_headers": ["SAMPLE_ID", "SAMPLE_METRIC_1", "SAMPLE_METRIC_2", "SAMPLE_METRIC_3"],
-		"sample_tsv": "custom_sample_annotation_with_nan.tsv"
+                "gene_headers": [
+                    "Gene",
+                    "Gene_metric_1",
+                    "Gene_metric_2",
+                    "Gene_metric_3"
+                ],
+                "gene_tsv": "custom_gene_annotation_with_nan.tsv",
+                "sample_headers": [
+                    "SAMPLE_ID",
+                    "SAMPLE_METRIC_1",
+                    "SAMPLE_METRIC_2",
+                    "SAMPLE_METRIC_3"
+                ],
+                "sample_tsv": "custom_sample_annotation_with_nan.tsv"
             },
             "workflow_run_id": "jabberwocky_workflow_run_0001"
         }
@@ -53,7 +63,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
-	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
+            "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",
@@ -61,7 +71,7 @@
             "SEQUENZA_PLOIDY": null,
             "SEQUENZA_PURITY_FRACTION": null,
             "SEX": "Male",
-	    "TMB_PER_MB":  null,
+            "TMB_PER_MB": null,
             "TREATMENT_STATUS": "Naive"
         }
     ],

--- a/src/test/data/study_config.json
+++ b/src/test/data/study_config.json
@@ -61,7 +61,8 @@
             "SEX": "Male",
             "ETHNICITY": "Other",
             "FRACTION_GENOME_ALTERED": 0.33,
-            "TMB_PER_MB": 82.38
+            "TMB_PER_MB": 82.38,
+	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in."
         }
     ],
     "genetic_alterations": [

--- a/src/test/data/study_config.json
+++ b/src/test/data/study_config.json
@@ -1,23 +1,29 @@
 {
     "study_meta": {
-	"type_of_cancer": "ductal carcinoma",
-	"cancer_study_identifier": "djerba_test_001",
-	"name": "Djerba Test 001",
-	"description": "Test of Djerba software package (September 2020)",
-	"citation": null,
-	"pmid": null,
-	"short_name": "Djerba 001",
-	"groups": null,
-	"add_global_case_list": true,
-	"tags_file": null,
-	"reference_genome": null
+        "type_of_cancer": "ductal carcinoma",
+        "cancer_study_identifier": "djerba_test_001",
+        "name": "Djerba Test 001",
+        "description": "Test of Djerba software package (September 2020)",
+        "citation": null,
+        "pmid": null,
+        "short_name": "Djerba 001",
+        "groups": null,
+        "add_global_case_list": true,
+        "tags_file": null,
+        "reference_genome": null
     },
     "cancer_type": {
         "type_of_cancer": null,
-        "name": ["Ductal Carcinoma"],
-        "clinical_trial_keywords": ["carcinoma,ductal carcinoma"],
+        "name": [
+            "Ductal Carcinoma"
+        ],
+        "clinical_trial_keywords": [
+            "carcinoma,ductal carcinoma"
+        ],
         "dedicated_color": null,
-        "parent_type_of_cancer": ["tissue"],
+        "parent_type_of_cancer": [
+            "tissue"
+        ],
         "data_filename": "cancer_type.txt"
     },
     "case_lists": [
@@ -25,21 +31,38 @@
             "suffix": "custom",
             "case_list_name": "djerba_custom_case_list",
             "case_list_description": "custom case list demonstration",
-            "case_list_ids": ["OCT-01-0472-CAP"],
+            "case_list_ids": [
+                "OCT-01-0472-CAP"
+            ],
             "case_list_category": null
         }
     ],
     "samples_meta": {
-        "display_names": ["Patient identifier", "Sample identifier"],
-        "descriptions": ["Patient identifier", "Sample identifier"],
-        "datatypes": ["STRING", "STRING"],
-        "priorities": [1,1],
-        "attribute_names": ["PATIENT_ID", "SAMPLE_ID"],
+        "display_names": [
+            "Patient identifier",
+            "Sample identifier"
+        ],
+        "descriptions": [
+            "Patient identifier",
+            "Sample identifier"
+        ],
+        "datatypes": [
+            "STRING",
+            "STRING"
+        ],
+        "priorities": [
+            1,
+            1
+        ],
+        "attribute_names": [
+            "PATIENT_ID",
+            "SAMPLE_ID"
+        ],
         "write_patients": true,
         "precision": 3
     },
     "samples": [
-	{
+        {
             "PATIENT_ID": "OCT-01-0472",
             "SAMPLE_ID": "OCT-01-0472-CAP",
             "COSMIC_SIGS": "Signature 6 (0.161)",
@@ -62,53 +85,56 @@
             "ETHNICITY": "Other",
             "FRACTION_GENOME_ALTERED": 0.33,
             "TMB_PER_MB": 82.38,
-	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in."
+            "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in."
         }
     ],
     "genetic_alterations": [
-	{
-	    "genetic_alteration_type": "MUTATION_EXTENDED_dummy_test",
-	    "workflow_run_id": "jabberwocky_workflow_run_0002",
-	    "datatype": "MAF",
-	    "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests/data/Strelka",
-	    "metadata": {
-		"oncokb_api_token": "e326982a-02ba-4f04-8ef6-80b04fa74acd",
-		"filter_vcf": "/.mounts/labs/gsiprojects/gsi/cBioGSI/data/reference/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz"
-	    },
-	    "input_files": {
-		"OCT-01-0472-CAP": "OCT-01-0472-CAP.sorted.filter.dedup.P.GID1.final.strelka.snvs.vcf.gz"
-	    }
-	},
-	{
-	    "genetic_alteration_type": "COPY_NUMBER_ALTERATION",
-	    "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests/data/CAP_CNA",
-	    "workflow_run_id": "frumious_workflow_run_0047",
-	    "datatype": "SEG",
-	    "metadata": {
-		"oncokb_api_token": "e326982a-02ba-4f04-8ef6-80b04fa74acd"
-	    },
-	    "input_files": {
-		"OCT-01-0472-CAP": "OCT-01-0472-CAP.tumour.bam.varscanSomatic_Total_CN.seg"
-	    }
-	},
-	{
-	    "genetic_alteration_type": "MRNA_EXPRESSION",
-	    "workflow_run_id": "vorpal_workflow_run_0022",
-	    "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression",
-	    "datatype": "MULTIPLE_TYPES",
-	    "datatypes": ["CONTINUOUS", "ZSCORE"],
-	    "metadata": {
-		"zscores": true,
-		"profile_name": "mRNA Expression",
-		"profile_description": "Expression information DCIS (5 Samples)",
-		"gepfile": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/gepcomp.list",
-		"gepcomp": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/gepcomp",
-		"tcgadata": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/TCGA_ALL_TUMOR.csv",
-		"studyid": "OCTCAP"
-	    },
-	    "input_files": {
-		"OCT-01-0472-CAP": "OCT-01-0472-TS_191121_A00469_0067_BHK3JLDSXX_ATTCAGAA-CCTATCCT_L001.genes.results"
-	    }
-	}
+        {
+            "genetic_alteration_type": "MUTATION_EXTENDED_dummy_test",
+            "workflow_run_id": "jabberwocky_workflow_run_0002",
+            "datatype": "MAF",
+            "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests/data/Strelka",
+            "metadata": {
+                "oncokb_api_token": "e326982a-02ba-4f04-8ef6-80b04fa74acd",
+                "filter_vcf": "/.mounts/labs/gsiprojects/gsi/cBioGSI/data/reference/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz"
+            },
+            "input_files": {
+                "OCT-01-0472-CAP": "OCT-01-0472-CAP.sorted.filter.dedup.P.GID1.final.strelka.snvs.vcf.gz"
+            }
+        },
+        {
+            "genetic_alteration_type": "COPY_NUMBER_ALTERATION",
+            "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests/data/CAP_CNA",
+            "workflow_run_id": "frumious_workflow_run_0047",
+            "datatype": "SEG",
+            "metadata": {
+                "oncokb_api_token": "e326982a-02ba-4f04-8ef6-80b04fa74acd"
+            },
+            "input_files": {
+                "OCT-01-0472-CAP": "OCT-01-0472-CAP.tumour.bam.varscanSomatic_Total_CN.seg"
+            }
+        },
+        {
+            "genetic_alteration_type": "MRNA_EXPRESSION",
+            "workflow_run_id": "vorpal_workflow_run_0022",
+            "input_directory": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression",
+            "datatype": "MULTIPLE_TYPES",
+            "datatypes": [
+                "CONTINUOUS",
+                "ZSCORE"
+            ],
+            "metadata": {
+                "zscores": true,
+                "profile_name": "mRNA Expression",
+                "profile_description": "Expression information DCIS (5 Samples)",
+                "gepfile": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/gepcomp.list",
+                "gepcomp": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/gepcomp",
+                "tcgadata": "/.mounts/labs/gsiprojects/gsi/cBioGSI/tests-handlers/data/CAP_expression/TCGA_ALL_TUMOR.csv",
+                "studyid": "OCTCAP"
+            },
+            "input_files": {
+                "OCT-01-0472-CAP": "OCT-01-0472-TS_191121_A00469_0067_BHK3JLDSXX_ATTCAGAA-CCTATCCT_L001.genes.results"
+            }
+        }
     ]
 }

--- a/src/test/data/study_config_mx.json
+++ b/src/test/data/study_config_mx.json
@@ -31,15 +31,15 @@
             "input_files": {
                 "OCT-01-0472-CAP": "somatic01.maf.txt.gz"
             },
-	    "input_directory": "/.mounts/labs/gsiprojects/gsi/djerba/mutation_extended",
+            "input_directory": "/.mounts/labs/gsiprojects/gsi/djerba/mutation_extended",
             "metadata": {
                 "filter_vcf": "/.mounts/labs/gsiprojects/gsi/cBioGSI/data/reference/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz",
                 "oncokb_api_token": "e326982a-02ba-4f04-8ef6-80b04fa74acd",
                 "profile_description": "Dummy profile for Djerba test",
                 "profile_name": "Djerba test 001",
-		"bed_path": "/.mounts/labs/gsiprojects/gsi/djerba/prototypes/tmb/S31285117_Regions.bed",
-		"tcga_path": "/.mounts/labs/gsiprojects/gsi/djerba/prototypes/tmb/tcga_tmbs.txt",
-		"cancer_type": "blca"
+                "bed_path": "/.mounts/labs/gsiprojects/gsi/djerba/prototypes/tmb/S31285117_Regions.bed",
+                "tcga_path": "/.mounts/labs/gsiprojects/gsi/djerba/prototypes/tmb/tcga_tmbs.txt",
+                "cancer_type": "blca"
             },
             "workflow_run_id": "jabberwocky_workflow_run_0001"
         }
@@ -58,7 +58,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
-	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
+            "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",
@@ -66,7 +66,7 @@
             "SEQUENZA_PLOIDY": null,
             "SEQUENZA_PURITY_FRACTION": null,
             "SEX": "Male",
-	    "TMB_PER_MB":  null,
+            "TMB_PER_MB": null,
             "TREATMENT_STATUS": "Naive"
         }
     ],

--- a/src/test/data/study_config_mx.json
+++ b/src/test/data/study_config_mx.json
@@ -58,6 +58,7 @@
             "MEAN_COVERAGE": null,
             "PATHOLOGICAL_REVIEW": "Lots of immune cells",
             "PATIENT_ID": "OCT-01-0472",
+	    "PATIENT_SUMMARY": "Nulla a scelerisque ipsum. Aliquam erat volutpat in.",
             "PCT_v7_ABOVE_80x": null,
             "SAMPLE_ANATOMICAL_SITE": "OMENTUM",
             "SAMPLE_ID": "OCT-01-0472-CAP",

--- a/src/test/test.py
+++ b/src/test/test.py
@@ -89,8 +89,8 @@ class TestReport(TestBase):
             report(config, self.sample_id, log_level=logging.ERROR).write_report_config(report_path)
             self.assertTrue(os.path.exists(report_path), "JSON report exists")
         checksums = {
-            report_names[0]: 'f783396939a9ccd5f1245cf614cfddc1',
-            report_names[1]: '1b78c3c3a382e7035a16804b7ee0180f'
+            report_names[0]: 'cda5dd11403673861c96461aae7e1957',
+            report_names[1]: '367c3c202234edf03aa2d6f5f6f65292'
         }
         self.verify_checksums(checksums, out_dir)
         # test with incorrect sample headers in metadata
@@ -110,7 +110,7 @@ class TestReport(TestBase):
         report_path = os.path.join(out_dir, report_name)
         report(config, self.sample_id, log_level=logging.ERROR).write_report_config(report_path)
         self.assertTrue(os.path.exists(report_path), "JSON report exists")
-        checksum = {report_name: 'a09078c361587a26e48019a21d5b3f43'}
+        checksum = {report_name: '3cdb4f97463fb1b77cc2effcb8112a17'}
         self.verify_checksums(checksum, out_dir)
         args = [config, 'nonexistent sample', logging.CRITICAL]
         self.assertRaises(DjerbaReportError, report, *args)


### PR DESCRIPTION
- Add `"Whizbam URL"` (gene-level) and `"PATIENT_SUMMARY"` (sample-level)
- Update Djerba config schema, test data and test checksums to include `PATIENT_SUMMARY` field. (Config schema does not specify gene-level metrics, as these are read in from data files.)