### PR TITLE
updated to python tools v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - GCGI-496 Expand list of permitted variant types in MAF
 - Updated README and added a diagram of Djerba structure
+- Updated to use Python Tools module v15 for Geneticist Review Report
 
 ### Fixed
 - GCGI-494 Fix input column header in `vaf_plot.R`

--- a/src/bin/qc_report.sh
+++ b/src/bin/qc_report.sh
@@ -15,13 +15,13 @@ fi
 REQUISITION=$1
 
 # Constants
-PYTHON_TOOLS_VER=14
+PYTHON_TOOLS_VER=15
 DB_CONFIG=/.mounts/labs/gsi/secrets/cap_reports_prod_db_config_ro.ini
 MISO_URL=https://miso.oicr.on.ca
 DASHI_URL=https://dashi.oicr.on.ca
 PINERY_URL=http://pinery.gsi.oicr.on.ca
 SAMPURU_ETL=/scratch2/groups/gsi/production/sampuru-etl
-QCETL_CACHE=/scratch2/groups/gsi/production/qcetl
+QCETL_CACHE=/scratch2/groups/gsi/production/qcetl_v1
 
 # We unload the current Python module (if any) and load production-tools-python
 # Resolves version conflict, eg. 3.9 for Djerba and 3.6 for production-tools-python


### PR DESCRIPTION
The only change in production-tools-python is an update to use gsi-qc-etl v1 instead of v0 as the v0 cache is being retired. There should be no changes to the reports or the data they contain