### PR TITLE
updated to python tools v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - GCGI-516 Change default file provenance report path to Vidarr
+- Updated to use Python Tools module v16 for Geneticist Review Report
 
 ## v0.3.10: 2022-10-25
 

--- a/src/bin/qc_report.sh
+++ b/src/bin/qc_report.sh
@@ -15,7 +15,7 @@ fi
 REQUISITION=$1
 
 # Constants
-PYTHON_TOOLS_VER=15
+PYTHON_TOOLS_VER=16
 DB_CONFIG=/.mounts/labs/gsi/secrets/cap_reports_prod_db_config_ro.ini
 MISO_URL=https://miso.oicr.on.ca
 DASHI_URL=https://dashi.oicr.on.ca


### PR DESCRIPTION
Changes:
* single lane clusters per sample now comes from fastqc instead of bamqc/rnaseqqc
* dnaseqqc is now used for other single lane WGS metrics if available; otherwise, bamqc is still used