### PR TITLE
Release v0.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.3.16: 2022-12-21
+
+### Fixed
+- GCGI-665 Bugfix; stops OncoKB link generation from crashing on fusions
+- Use OncoTree code, not TCGA code, to make OncoKB links
+- Clean up `msi.txt` output to remove trailing tab character
+
 ## v0.3.15: 2022-12-20
 
 ### GCGI-403: CouchDB

--- a/src/lib/djerba/extract/r_script_wrapper.py
+++ b/src/lib/djerba/extract/r_script_wrapper.py
@@ -325,8 +325,7 @@ class r_script_wrapper(logger):
                 msi_boots.append(float(row[3]))
         msi_perc = numpy.percentile(numpy.array(msi_boots), [0, 25, 50, 75, 100])
         with open(out_path, 'w') as out_file:
-            for item in list(msi_perc):
-                out_file.write(str(str(item)+"\t"))
+            print("\t".join([str(item) for item in list(msi_perc)]), file=out_file)
         return out_path
 
     def preprocess_seg(self, sequenza_path, tmp_dir):

--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -164,7 +164,6 @@ class clinical_report_json_composer(composer_base):
         self.failed = self.params.get(xc.FAILED)
         self.clinical_data = self.read_clinical_data()
         self.closest_tcga_lc = self.clinical_data[dc.CLOSEST_TCGA].lower()
-        self.closest_tcga_uc = self.clinical_data[dc.CLOSEST_TCGA].upper()
         self.oncotree_uc = self.params.get(xc.ONCOTREE_CODE).upper()
         self.data_dir = os.path.join(os.environ['DJERBA_BASE_DIR'], dc.DATA_DIR_NAME)
         self.r_script_dir = os.path.join(os.environ['DJERBA_BASE_DIR'], 'R_plots')
@@ -186,6 +185,7 @@ class clinical_report_json_composer(composer_base):
                 self.gene_pair_fusions = None
 
     def build_alteration_url(self, gene, alteration, cancer_code):
+        self.logger.debug('Constructing alteration URL from inputs: {0}'.format([self.ONCOKB_URL_BASE, gene, alteration, cancer_code]))
         return '/'.join([self.ONCOKB_URL_BASE, gene, alteration, cancer_code])
 
     def build_copy_number_variation(self):
@@ -801,8 +801,8 @@ class clinical_report_json_composer(composer_base):
         else:
             genes_and_urls = {gene: self.build_gene_url(gene) for gene in genes_arg}
         if alteration == rc.FUSION:
-            alt_url = self.build_alteration_url('-'.join(genes_arg), alteration, self.closest_tcga_uc)
-        if alteration == "TMB-H" or alteration == "MSI-H":
+            alt_url = self.build_alteration_url('-'.join(genes_arg), alteration, self.oncotree_uc)
+        elif alteration == "TMB-H" or alteration == "MSI-H":
             genes_and_urls = {
                 "Biomarker": core_biomarker_url
             }
@@ -811,7 +811,7 @@ class clinical_report_json_composer(composer_base):
             if alteration == "MSI-H":
                 alt_url = '/'.join([core_biomarker_url,"Microsatellite%20Instability-High/"])
         else:
-            alt_url = self.build_alteration_url(genes_arg, alteration, self.closest_tcga_uc)
+            alt_url = self.build_alteration_url(genes_arg, alteration, self.oncotree_uc)
         row = {
             rc.GENES_AND_URLS: genes_and_urls,
             rc.ALT: alteration,

--- a/src/lib/djerba/version.py
+++ b/src/lib/djerba/version.py
@@ -3,4 +3,4 @@
 # 2) we can import it in setup.py for the same reason
 # 3) it only needs to be stored in one place
 # See https://stackoverflow.com/a/16084844
-__version__ = '0.3.15'
+__version__ = '0.3.16'


### PR DESCRIPTION
- GCGI-665 Bugfix; stops OncoKB link generation from crashing on fusions
- Use OncoTree code, not TCGA code, to make OncoKB links
- Clean up `msi.txt` output to remove trailing tab character and eliminate warning from R script