### PR TITLE
Gcgi 720 splice site mutations

### DIFF
--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -401,7 +401,7 @@ class clinical_report_json_composer(composer_base):
                 cytoband = self.get_cytoband(gene)
                 protein = input_row[self.HGVSP_SHORT]
                 if 'splice' in protein:
-                    protein = input_row[self.HGVSC] + ' (p.?)'
+                    protein = 'p.? (' + input_row[self.HGVSC] + ')'  
                 row = {
                     rc.GENE: gene,
                     rc.GENE_URL: self.build_gene_url(gene),
@@ -498,7 +498,7 @@ class clinical_report_json_composer(composer_base):
                 gene = row[self.HUGO_SYMBOL_TITLE_CASE]
                 alteration = row[self.HGVSP_SHORT]
                 if 'splice' in alteration:
-                    alteration = row[self.HGVSC] + ' (p.?)'
+                    alteration = 'p.? (' + row[self.HGVSC] + ')'  
                 [max_level, therapies] = self.parse_max_oncokb_level_and_therapies(row, levels)
                 if max_level:
                     rows.append(self.treatment_row(gene, alteration, max_level, therapies))

--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -104,6 +104,7 @@ class clinical_report_json_composer(composer_base):
     GENOME_SIZE = 3*10**9 # TODO use more accurate value when we release a new report format
     GENOMIC_BIOMARKERS = 'genomic_biomarkers.maf'
     HGVSP_SHORT = 'HGVSp_Short'
+    HGVSC = 'HGVSc'
     HUGO_SYMBOL_TITLE_CASE = 'Hugo_Symbol'
     HUGO_SYMBOL_UPPER_CASE = 'HUGO_SYMBOL'
     MINIMUM_MAGNITUDE_SEG_MEAN = 0.2
@@ -399,6 +400,8 @@ class clinical_report_json_composer(composer_base):
                 gene = input_row[self.HUGO_SYMBOL_TITLE_CASE]
                 cytoband = self.get_cytoband(gene)
                 protein = input_row[self.HGVSP_SHORT]
+                if 'Splice_Site' in self.VARIANT_CLASSIFICATION:
+                    protein = input_row[self.HGVSC]
                 row = {
                     rc.GENE: gene,
                     rc.GENE_URL: self.build_gene_url(gene),

--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -497,6 +497,8 @@ class clinical_report_json_composer(composer_base):
             for row in csv.DictReader(data_file, delimiter="\t"):
                 gene = row[self.HUGO_SYMBOL_TITLE_CASE]
                 alteration = row[self.HGVSP_SHORT]
+                if 'Splice_Site' in self.VARIANT_CLASSIFICATION:
+                    alteration = row[self.HGVSC]
                 [max_level, therapies] = self.parse_max_oncokb_level_and_therapies(row, levels)
                 if max_level:
                     rows.append(self.treatment_row(gene, alteration, max_level, therapies))

--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -401,7 +401,7 @@ class clinical_report_json_composer(composer_base):
                 cytoband = self.get_cytoband(gene)
                 protein = input_row[self.HGVSP_SHORT]
                 if 'splice' in protein:
-                    protein = input_row[self.HGVSC]
+                    protein = input_row[self.HGVSC] + ' (p.?)'
                 row = {
                     rc.GENE: gene,
                     rc.GENE_URL: self.build_gene_url(gene),
@@ -498,7 +498,7 @@ class clinical_report_json_composer(composer_base):
                 gene = row[self.HUGO_SYMBOL_TITLE_CASE]
                 alteration = row[self.HGVSP_SHORT]
                 if 'splice' in alteration:
-                    alteration = row[self.HGVSC]
+                    alteration = row[self.HGVSC] + ' (p.?)'
                 [max_level, therapies] = self.parse_max_oncokb_level_and_therapies(row, levels)
                 if max_level:
                     rows.append(self.treatment_row(gene, alteration, max_level, therapies))

--- a/src/lib/djerba/extract/report_to_json.py
+++ b/src/lib/djerba/extract/report_to_json.py
@@ -400,7 +400,7 @@ class clinical_report_json_composer(composer_base):
                 gene = input_row[self.HUGO_SYMBOL_TITLE_CASE]
                 cytoband = self.get_cytoband(gene)
                 protein = input_row[self.HGVSP_SHORT]
-                if 'Splice_Site' in self.VARIANT_CLASSIFICATION:
+                if 'splice' in protein:
                     protein = input_row[self.HGVSC]
                 row = {
                     rc.GENE: gene,
@@ -497,7 +497,7 @@ class clinical_report_json_composer(composer_base):
             for row in csv.DictReader(data_file, delimiter="\t"):
                 gene = row[self.HUGO_SYMBOL_TITLE_CASE]
                 alteration = row[self.HGVSP_SHORT]
-                if 'Splice_Site' in self.VARIANT_CLASSIFICATION:
+                if 'splice' in alteration:
                     alteration = row[self.HGVSC]
                 [max_level, therapies] = self.parse_max_oncokb_level_and_therapies(row, levels)
                 if max_level:


### PR DESCRIPTION
In both the therapy section (alterations) and the SNVs/in/dels section (proteins), if the type is a splice site, (i.e. the protein name has "splice" in it), it'll instead put something of this form in the table, ex: c.7618-1G>A
(Passed testing)