### PR TITLE
Check all fields in config are non-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+- Raise an error in INI config validation if any parameters are set to an empty string
+
 ## v0.4.5: 2023-03-24
 
 ### Fixed

--- a/src/lib/djerba/util/validator.py
+++ b/src/lib/djerba/util/validator.py
@@ -38,14 +38,22 @@ class config_validator(logger):
 
     def validate(self, config, section_titles):
         """Validate for the given list of section titles"""
-        for title in section_titles:
-            if not title in config.sections():
-                msg = "[{0}] section not found in config".format(title)
+        for section in section_titles:
+            if not section in config.sections():
+                msg = "[{0}] section not found in config".format(section)
                 self.logger.error(msg)
                 raise DjerbaConfigError(msg)
-            for field in self.schema[title]:
-                if not config[title].get(field):
-                    msg = "[{0}] field '{1}' not found in config".format(title, field)
+            for field in self.schema[section]:
+                if not config[section].get(field):
+                    msg = "[{0}] field '{1}' not found in config".format(section, field)
+                    self.logger.error(msg)
+                    raise DjerbaConfigError(msg)
+        # check all fields in config are non-empty
+        # ConfigParser interprets 'foo=' as mapping foo to the empty string
+        for section in config.sections():
+            for field in config[section]:
+                if config[section][field]=='':
+                    msg = "[{0}] field '{1}' cannot be an empty string".format(section, field)
                     self.logger.error(msg)
                     raise DjerbaConfigError(msg)
         return True


### PR DESCRIPTION
Logging for an empty field will look like this:
`
2023-03-28_09:59:52 djerba.util.validator INFO: Validating config for WGTS report
2023-03-28_09:59:52 djerba.main INFO: Running Djerba in mode: configure
2023-03-28_09:59:52 djerba.util.validator ERROR: [discovered] field 'sample_name_whole_genome_normal' cannot be an empty string
`