### PR TITLE
GCGI-870 biomarker cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+- GCGI-870: Fix for biomarker annotation cache; required for benchmark cron
+
 ## v0.4.9: 2023-05-15
 
 ### Changed
@@ -8,13 +13,13 @@
 - GCGI-885: Changed "Small regions (&#60;3 Mb) with large copy number gains" to "Regions with large copy number gains (&#8805; 6 CN)"
 
 ### Fixed
-- GCGI-885: Fixed splice site reporting 
+- GCGI-885: Fixed splice site reporting
 
 ## v0.4.8: 2023-04-25
 
 ### Changed
 - updated version of Arriba from 1.2.0 to 2.4.0
-- updated version of STAR from 2.7.3a to 2.7.10b 
+- updated version of STAR from 2.7.3a to 2.7.10b
 - updated pipeline version to 3.0
 
 ### Fixed

--- a/doc/oncokb_cache.md
+++ b/doc/oncokb_cache.md
@@ -9,11 +9,11 @@ Caching of OncoKB annotation has the following advantages:
 - Automated tests can be run without accessing the internet
 - Reduces demands on the OncoKB server, especially during intensive testing
 
-## Location and format
+## Location and cache files
 
 The cache is read from and/or written to a directory specified in the `oncokb_cache` field of the `[settings]` section in the Djerba INI file. A default cache location is configured with other default settings in [defaults.ini](../src/lib/djerba/data/defaults.ini). Cache files are written to a subdirectory named for the OncoTree code, eg. `paad` for pancreatic adenocarcinoma. Note that the `oncokb-annotator` scripts take the OncoTree code as input, and annotation may differ between OncoTree codes.
 
-The cache for a given OncoTree code contains three JSON files, one each for CNA, fusion and MAF annotations. Each file contains a dictionary of annotations, whose keys are identifiers for the un-annotated input lines.
+The cache for a given OncoTree code contains three JSON files, one each for CNA, fusion and MAF annotations. Each file contains a dictionary of annotations, whose keys are identifiers for the un-annotated input lines. See `JSON format` below for details of the file structure.
 
 ## Cache operations
 
@@ -54,3 +54,38 @@ A number of automated Djerba tests use the OncoKB cache to run more quickly and 
 If a clinical report is being generated multiple times, such as for tests or troubleshooting, waiting for annotation can be quite time-consuming. In this case, `djerba.py` can be used with `--update-cache` on an initial run, to populate the cache; and on subsequent runs with `--apply-cache`. The default cache for manual usage is _not_ backed up or controlled in any way, and should be considered a scratch space only.
 
 The script `update_oncokb_cache.py` will update the cache files for given input and output directories. It is _not_ aware of the oncotree code, and should be given the full path to the cache directory.
+
+### Previously unseen sample names are not supported
+
+Cached values for MAF files do _not_ generalize to previously unseen sample names. In other words, the values are specific to a sample, not only a gene or variant type. This is not an issue in current cache usage for tests and benchmarking. Extending the MAF cache to new samples is a possible task for future development.
+
+Fusion and CNA caches will generalize, but this behaviour has not been tested. Because of the MAF issue, using the cache for novel sample names is not recommended.
+
+See "JSON format" below for details.
+
+## JSON format
+
+Each row in a MAF, CNA, or fusion file corresponds to a value in the cache file, identified by a key.
+
+### MAF
+
+Keys are a unique identifier generated from a subset of columns in the MAF file. Specifically, the key is the `sha256` checksum of the first `N` columns of the MAF row -- where `N` is defined as the column immediately _before_ the column with header `ANNOTATED`.
+
+- In a small mutations and indels MAF file, `N` equals 116.
+- In a genomic biomarkers MAF file, `N` equals 3.
+
+In both the above cases, the input to the checksum includes the sample name. So cached annotation will _not_ generalize to samples not previously encountered.
+
+Values are lists containing the annotation fields, ie. all row values from `N+1` onwards.
+
+### CNA
+
+For CNA annotation, we distinguish between amplifications and deletions.
+
+The top-level key is the gene name. This maps to a dictionary with (at most) two entries, for "Amplification" and "Deletion". The value for of each entry is a list of annotation values. Similarly to MAF cache values, the list consists of all column entries, starting with the column headed `ANNOTATED`.
+
+### Fusion
+
+Keys are the fusion name with `-` separator, instead of the more modern `::` separator, for consistency with legacy file formats.
+
+Values are a list consisting of all column entries, starting with the column headed `ANNOTATED`, similarly to MAF and CNA files.

--- a/src/lib/djerba/extract/oncokb/annotator.py
+++ b/src/lib/djerba/extract/oncokb/annotator.py
@@ -147,6 +147,7 @@ class oncokb_annotator(logger):
         it can't use 'Genomic_Change'"""
         self.validator.validate_input_file(in_path)
         if self.apply_cache:
+            self.logger.debug("Applying cache for biomarker annotation")
             self.cache.annotate_maf(in_path, out_path)
         else:
             cmd = [
@@ -158,6 +159,7 @@ class oncokb_annotator(logger):
             ]
             self._run_annotator_script(cmd, 'MAF annotator')
             if self.update_cache:
+                self.logger.debug("Updating cache for biomarker annotation")
                 self.cache.write_maf_cache(out_path)
         return out_path
 

--- a/src/test/test.py
+++ b/src/test/test.py
@@ -387,7 +387,7 @@ class TestExtractor(TestBase):
             xc.ASSAY_TYPE: "WGS",
             xc.COVERAGE: 80,
             xc.FAILED: False,
-            xc.ONCOKB_CACHE: oncokb_cache_params,
+            xc.ONCOKB_CACHE: oncokb_cache_params(),
             xc.ONCOTREE_CODE: "PAAD",
             xc.PURITY_FAILURE: False, 
             xc.PROJECT: "PASS01"


### PR DESCRIPTION
- Fix caching for biomarkers by suppling non-empty cache params to the OncoKB annotator
- Fix biomarker test to input an `oncokb_cache_params` object, not the class