### PR TITLE
GCGI 806 expression diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - ACD -> ACDx
 - Added "-" between date and report name in footer
+- GCGI-806: Modify `benchmark.py` interface; remove `--compare-all` option; add `--delta` argument for permitted difference in expression levels
 
 ### Fixed
 - GCGI-870: Fix for biomarker annotation cache; required for benchmark cron
@@ -15,7 +16,6 @@
 - GCGI-883: Added date to footer of pdf, as in ISO requirement
 - GCGI-865: replaced MSI LLOD text
 - GCGI-885: Changed "Small regions (&#60;3 Mb) with large copy number gains" to "Regions with large copy number gains (&#8805; 6 CN)"
-
 ### Fixed
 - GCGI-885: Fixed splice site reporting
 

--- a/src/bin/benchmark.py
+++ b/src/bin/benchmark.py
@@ -20,7 +20,7 @@ def get_parser():
     parser.add_argument('-l', '--log-path', metavar='PATH', help='Output file for log messages; defaults to STDERR')
     subparsers = parser.add_subparsers(title='subcommands', help='sub-command help', dest='subparser_name')
     compare_parser = subparsers.add_parser(constants.COMPARE, help='Compare two sets of Djerba benchmark reports')
-    compare_parser.add_argument('-a', '--all', action='store_true', dest='compare_all', help='Compare all contents of JSON files. If not given, default is to compare report elements only, not supplementary.')
+    compare_parser.add_argument('-D', '--delta', metavar='NUM', type=float, default=0.1, help='Permitted difference in equivalent expression levels, must be between 0 and 1')
     compare_parser.add_argument('-r', '--report-dir', metavar='DIR', action='append', required=True, help='Directory of reports, as generated in \'report\' mode; must be supplied twice')
     report_parser = subparsers.add_parser(constants.REPORT, help='Set up and (optionally) generate Djerba reports')
     report_parser.add_argument('-i', '--input-dir', metavar='DIR', required=True, help='Directory to scan for workflow outputs, eg. ./GSICAPBENCHyymmdd/seqware-results/')

--- a/src/lib/djerba/benchmark.py
+++ b/src/lib/djerba/benchmark.py
@@ -15,6 +15,7 @@ import djerba.render.constants as rc
 import djerba.util.constants as constants
 import djerba.util.ini_fields as ini
 
+from copy import deepcopy
 from glob import glob
 from string import Template
 from djerba.main import main
@@ -125,39 +126,39 @@ class benchmarker(logger):
 
     def run_comparison(self, report_dirs):
         name = constants.REPORT_JSON_FILENAME
-        data_to_compare = []
+        data = []
         report_paths = []
-        if self.args.compare_all:
-            self.logger.info("Comparing all document contents, including supplementary data")
-        else:
-            self.logger.info("Comparing report elements, excluding supplementary data")
+        self.logger.info("Comparing report elements, excluding supplementary data")
         self.logger.debug("Comparing reports: {0}".format(report_dirs))
         for report_dir in report_dirs:
             self.validator.validate_input_dir(report_dir)
             report_path = self.glob_single('{0}/**/{1}'.format(report_dir, name))
+            if report_path == None:
+                msg = "{0} not found in {1}".format(name, report_dir)
+                self.logger.error(msg)
+                raise RuntimeError(msg)
             self.validator.validate_input_file(report_path)
             report_paths.append(report_path)
-            data = self.read_and_preprocess_report(report_path)
-            if self.args.compare_all:
-                data_to_compare.append(data)
-            else:
-                data_to_compare.append(data.get(constants.REPORT))
+            doc = self.read_and_preprocess_report(report_path)
+            data.append(doc.get(constants.REPORT))
         self.logger.debug("Found report paths: {0}".format(report_paths))
         if os.path.samefile(report_paths[0], report_paths[1]):
             msg = "Report paths are the same file! {0}".format(report_paths)
             self.logger.error(msg)
             raise RuntimeError(msg)
-        diff = ReportDiff(data_to_compare)
-        equivalent = diff.is_equivalent()
-        if equivalent:
+        if self.args.delta < 0 or self.args.delta > 1:
+            msg = "Delta must be between 0 and 1; found {0}".format(self.args.delta)
+            self.logger.error(msg)
+            raise ValueError(msg)
+        diff = report_equivalence_tester(data, self.args.delta, self.log_level, self.log_path)
+        if diff.is_equivalent():
             self.logger.info("Reports are equivalent: {0}".format(report_paths))
         else:
             self.logger.warning("Reports are NOT equivalent: {0}".format(report_paths))
             if self.log_level > logging.INFO:
                 self.logger.warning("Run with --debug or --verbose for full report diff")
-            else:
-                self.logger.info("Report diff:\n{0}".format(diff.get_diff()))
-        return equivalent
+        self.logger.info("Report diff: {0}".format(diff.get_diff_text()))
+        return diff.is_equivalent()
 
     def run_reports(self, input_samples, work_dir):
         self.logger.info("Reporting for {0} samples: {1}".format(len(input_samples), input_samples))
@@ -261,24 +262,141 @@ class main_draft_args():
         self.update_cache = update_cache
         self.wgs_only = False
 
+class report_equivalence_tester(logger):
+
+    def __init__(self, data, expression_delta, log_level=logging.WARNING, log_path=None):
+        self.logger = self.get_logger(log_level, __name__, log_path)
+        self.data = data
+        self.delta = expression_delta
+        diff = ReportDiff(self.data)
+        self.diff_text = diff.get_diff()
+        if diff.is_identical():
+            self.logger.info("EQUIVALENT: Reports are identical")
+            self.equivalent = True
+        elif self.expressions_are_equivalent():
+            # check for non-expression discrepancies
+            diff_no_expr = ReportDiff(self.remove_expression())
+            self.equivalent = diff_no_expr.is_identical()
+            if self.equivalent:
+                msg = "EQUIVALENT: Reports are not identical, "+\
+                      "but equivalent within expression tolerance"
+            else:
+                msg = "NOT EQUIVALENT: Expressions are within tolerance, "+\
+                      "but other report fields differ"
+            self.logger.info(msg)
+        else:
+            msg = "NOT EQUIVALENT: Expressions do not match within "+\
+                  "permitted tolerance; other values may also differ"
+            self.logger.info(msg)
+            self.equivalent = False
+
+    def is_equivalent(self):
+        return self.equivalent
+
+    def get_diff_text(self):
+        return self.diff_text
+
+    def expressions_are_equivalent(self):
+        """
+        Check if input data structures are equivalent
+        Expression levels are permitted to differ by +/- delta
+        """
+        keys = [rc.TOP_ONCOGENIC_SOMATIC_CNVS, rc.SMALL_MUTATIONS_AND_INDELS]
+        expressions = []
+        # find expression by gene, for both datasets, and for both SNVs/indels and CNVs
+        for doc in self.data:
+            expr = {}
+            for key in keys:
+                for alteration in doc[key][rc.BODY]:
+                    expr[alteration[rc.GENE]] = alteration[rc.EXPRESSION_METRIC]
+            expressions.append(expr)
+        # compare the two expression dictionaries
+        if set(expressions[0].keys()) != set(expressions[1].keys()):
+            self.logger.info("Expression gene sets differ, expressions are not equivalent")
+            equivalent = False
+        else:
+            equivalent = True
+            for gene in expressions[0].keys():
+                expr0 = expressions[0][gene]
+                expr1 = expressions[1][gene]
+                if (expr0==None and expr1!=None) or (expr0!=None and expr1==None):
+                    msg = "Expression levels for gene {0}".format(gene)+\
+                          "have mismatched null and non-null values; "+\
+                          "expressions are not equivalent"
+                    self.logger.info(msg)
+                    equivalent = False
+                    break
+                elif expr0==None and expr1==None:
+                    pass # both expressions null is OK
+                else:
+                    diff = abs(expr0 - expr1)
+                    if diff > self.delta:
+                        msg = "Expression levels for gene {0} differ ".format(gene)+\
+                              "by more than permitted maximum of {0}; ".format(self.delta)+\
+                              "expressions are not equivalent"
+                        self.logger.info(msg)
+                        equivalent = False
+                        break
+            if equivalent:
+                msg = "All expression levels are within permitted tolerance "+\
+                      "of {0}; expressions are equivalent".format(self.delta)
+                self.logger.info(msg)
+        return equivalent
+
+    def remove_expression(self):
+        # return a copy of the Djerba report with expression values zeroed out
+        data_copy = deepcopy(self.data)
+        keys = [rc.TOP_ONCOGENIC_SOMATIC_CNVS, rc.SMALL_MUTATIONS_AND_INDELS]
+        for doc in data_copy:
+            for key in keys:
+                for alteration in doc[key][rc.BODY]:
+                    alteration[rc.EXPRESSION_METRIC] = 0
+        return data_copy
+
+    def compare_reports(self):
+        diff = ReportDiff(self.data)
+        self.diff_text = diff.get_diff()
+        if diff.is_identical():
+            self.logger.info("Equivalence TRUE: Reports are identical")
+            equivalent = True
+        elif self.expressions_are_equivalent(data):
+            # check for non-expression discrepancies
+            data_no_expr = self.remove_expression(data)
+            diff_no_expr = ReportDiff(data_no_expr)
+            equivalent = diff_no_expr.is_identical()
+            if equivalent:
+                msg = "Equivalence TRUE: Reports are not identical, "+\
+                      "but equivalent within expression tolerance"
+            else:
+                msg = "Equivalence FALSE: Expressions are within tolerance, "+\
+                      "but other report fields differ"
+            self.logger.info(msg)
+        else:
+            msg = "Equivalence FALSE: Expressions differ by greater than "+\
+                  "permitted tolerance; other values may also differ."
+            self.logger.info(msg)
+            equivalent = False
+        return equivalent
+
 class ReportDiff(unittest.TestCase):
     """Use a test assertion to diff two data structures"""
 
     def __init__(self, data):
         super().__init__()
+        self.data = data
         if len(data)!=2:
             raise RuntimeError("Expected 2 inputs, found {0}".format(len(data)))
         self.maxDiff = None
         try:
             self.assertEqual(data[0], data[1])
-            self.diff=''
-            self.equivalent = True
+            self.diff='NONE'
+            self.identical = True
         except AssertionError as err:
             self.diff = str(err)
-            self.equivalent = False
+            self.identical = False
 
     def get_diff(self):
         return self.diff
 
-    def is_equivalent(self):
-        return self.equivalent
+    def is_identical(self):
+        return self.identical

--- a/src/lib/djerba/benchmark.py
+++ b/src/lib/djerba/benchmark.py
@@ -353,30 +353,6 @@ class report_equivalence_tester(logger):
                     alteration[rc.EXPRESSION_METRIC] = 0
         return data_copy
 
-    def compare_reports(self):
-        diff = ReportDiff(self.data)
-        self.diff_text = diff.get_diff()
-        if diff.is_identical():
-            self.logger.info("Equivalence TRUE: Reports are identical")
-            equivalent = True
-        elif self.expressions_are_equivalent(data):
-            # check for non-expression discrepancies
-            data_no_expr = self.remove_expression(data)
-            diff_no_expr = ReportDiff(data_no_expr)
-            equivalent = diff_no_expr.is_identical()
-            if equivalent:
-                msg = "Equivalence TRUE: Reports are not identical, "+\
-                      "but equivalent within expression tolerance"
-            else:
-                msg = "Equivalence FALSE: Expressions are within tolerance, "+\
-                      "but other report fields differ"
-            self.logger.info(msg)
-        else:
-            msg = "Equivalence FALSE: Expressions differ by greater than "+\
-                  "permitted tolerance; other values may also differ."
-            self.logger.info(msg)
-            equivalent = False
-        return equivalent
 
 class ReportDiff(unittest.TestCase):
     """Use a test assertion to diff two data structures"""

--- a/src/test/test_benchmark.py
+++ b/src/test/test_benchmark.py
@@ -3,19 +3,20 @@
 from test import TestBase
 import os
 import unittest
+from copy import deepcopy
 from shutil import copytree
 import djerba.util.constants as constants
-from djerba.benchmark import benchmarker
+from djerba.benchmark import benchmarker, report_equivalence_tester
 
-class TestBenchmark(TestBase):
+class TestReport(TestBase):
 
     class mock_args_compare:
         """Use instead of argparse to store params for testing"""
 
-        def __init__(self, report_dirs, compare_all=False):
+        def __init__(self, report_dirs):
             self.subparser_name = constants.COMPARE
             self.report_dir = report_dirs
-            self.compare_all = compare_all
+            self.delta = 0.1
             # logging
             self.log_path = None
             self.debug = False
@@ -54,11 +55,60 @@ class TestBenchmark(TestBase):
         self.assertTrue(benchmarker(compare_args_1).run())
         compare_args_2 = self.mock_args_compare([report_1a, report_2])
         self.assertFalse(benchmarker(compare_args_2).run())
-        compare_args_3 = self.mock_args_compare([report_1a, report_1b], compare_all=True)
-        self.assertTrue(benchmarker(compare_args_3).run())
-        compare_args_4 = self.mock_args_compare([report_1a, report_2], compare_all=True)
-        self.assertFalse(benchmarker(compare_args_4).run())
 
+class TestEquivalence(TestBase):
+
+    # simplified report structure with mock expression levels
+    EXAMPLE = {
+        "oncogenic_somatic_CNVs": {
+            "Body": [
+                {
+                    "Expression Percentile": 0.4,
+                    "Gene": "FGFR1",
+                },
+                {
+                    "Expression Percentile": 1.0,
+                    "Gene": "FGFR4",
+                }
+            ]
+        },
+        "small_mutations_and_indels": {
+            "Body": [
+                {
+                    "Expression Percentile": 0.5224,
+                    "Gene": "CDKN2A",
+                },
+                {
+                    "Expression Percentile": 0.9,
+                    "Gene": "KRAS",
+                }
+            ]
+        }
+    }
+
+    def test_equivalence(self):
+        tester1 = report_equivalence_tester([self.EXAMPLE, self.EXAMPLE], 0.1)
+        self.assertTrue(tester1.is_equivalent())
+        modified = deepcopy(self.EXAMPLE)
+        cnv = "oncogenic_somatic_CNVs"
+        expr = "Expression Percentile"
+        modified[cnv]["Body"][0][expr] = 0.7 # was 0.4
+        tester2 = report_equivalence_tester([self.EXAMPLE, modified], 0.1)
+        self.assertFalse(tester2.is_equivalent())
+        tester3 = report_equivalence_tester([self.EXAMPLE, modified], 0.5)
+        self.assertTrue(tester3.is_equivalent())
+        extra = {
+            "Expression Percentile": 0.9,
+            "Gene": "BRCA2"
+        }
+        with_extra_gene = deepcopy(modified)
+        with_extra_gene[cnv]["Body"].append(extra)
+        tester4 = report_equivalence_tester([self.EXAMPLE, with_extra_gene], 0.5)
+        self.assertFalse(tester4.is_equivalent())
+        with_extra_other = deepcopy(self.EXAMPLE)
+        with_extra_other["foo"] = "bar"
+        tester5 = report_equivalence_tester([self.EXAMPLE, with_extra_other], 0.5)
+        self.assertFalse(tester5.is_equivalent())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Modify `benchmark.py`
- Handle the situation where expression levels differ slightly in otherwise identical reports
- Add `--delta` option. In comparison mode, expression levels may differ by at most the value of delta (default = 0.1)
- Remove `--compare-all` option; comparison is applied to `report` elements only, not `supplementary`
- Update tests
