### PR TITLE
Gcgi 955 specify params method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+### GCGI-955: `specify_params`
+- Each plugin must have a `specify_params` method to define required and optional INI parameters
+- Using an INI parameter not defined in `specify_params` will cause an error
+- Refactor INI and priority handling to enable `specify_params`
+
 ## v1.0.0-dev0.0.5: 2023-07-04
 
 ### GCGI-946: Versioning for plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Using an INI parameter not defined in `specify_params` will cause an error
 - Refactor INI and priority handling to enable `specify_params`
 
+### Other
+- Strict substitution for environment variable templates; consistent with HOWTO on wiki
+
 ## v1.0.0-dev0.0.5: 2023-07-04
 
 ### GCGI-946: Versioning for plugins

--- a/src/lib/djerba/core/configure.py
+++ b/src/lib/djerba/core/configure.py
@@ -85,7 +85,7 @@ class configurable(logger, ABC):
 
     def apply_defaults(self, config):
         """
-        Apply default parameters to the given ConfigParser or config_wrapper
+        Apply default parameters to the given ConfigParser
         This method does not overwrite existing values
         """
         for key in self.ini_defaults:
@@ -154,14 +154,9 @@ class configurable(logger, ABC):
     def validate_priorities(self, config):
         # check priorities are non-negative integers
         # TODO sanity checking on other reserved params
-        priorities = [
-            core_constants.CONFIGURE_PRIORITY,
-            core_constants.EXTRACT_PRIORITY,
-            core_constants.RENDER_PRIORITY
-        ]
         ok = True
         for s in config.sections():
-            for p in priorities:
+            for p in core_constants.PRIORITY_KEYS:
                 if config.has_option(s, p):
                     try:
                         v = config.getint(s, p)
@@ -182,11 +177,6 @@ class configurer(configurable):
     """Class to do core configuration"""
 
     PRIORITY = 0
-    PRIORITY_KEYS = [
-        core_constants.CONFIGURE_PRIORITY,
-        core_constants.EXTRACT_PRIORITY,
-        core_constants.RENDER_PRIORITY
-    ]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -198,7 +188,7 @@ class configurer(configurable):
         return config
 
     def set_priority_defaults(self, priority):
-        for key in self.PRIORITY_KEYS:
+        for key in core_constants.PRIORITY_KEYS:
             self.ini_defaults[key] = priority
 
     def specify_params(self):

--- a/src/lib/djerba/core/constants.py
+++ b/src/lib/djerba/core/constants.py
@@ -12,6 +12,12 @@ SUPPLEMENTARY = 'supplementary'
 CONFIGURE_PRIORITY = 'configure_priority'
 EXTRACT_PRIORITY = 'extract_priority'
 RENDER_PRIORITY = 'render_priority'
+PRIORITY_KEYS = [
+    CONFIGURE_PRIORITY,
+    EXTRACT_PRIORITY,
+    RENDER_PRIORITY
+]
+
 PRIORITIES = 'priorities'
 CONFIGURE = 'configure'
 EXTRACT = 'extract'

--- a/src/lib/djerba/core/main.py
+++ b/src/lib/djerba/core/main.py
@@ -22,7 +22,7 @@ from djerba.core.loaders import \
 from djerba.core.workspace import workspace
 from djerba.util.logger import logger
 from djerba.util.validator import path_validator
-import djerba.core.constants as core_constants
+import djerba.core.constants as cc
 import djerba.util.constants as constants
 
 class main(core_base):
@@ -31,7 +31,7 @@ class main(core_base):
     PLUGINS = 'plugins'
     MERGERS = 'mergers'
     MERGE_INPUTS = 'merge_inputs'
-    
+
     def __init__(self, work_dir=None, log_level=logging.INFO, log_path=None):
         self.log_level = log_level
         self.log_path = log_path
@@ -50,7 +50,7 @@ class main(core_base):
         self.helper_loader = helper_loader(self.log_level, self.log_path)
 
     def _get_render_priority(self, plugin_data):
-        return plugin_data[core_constants.PRIORITIES][core_constants.RENDER]
+        return plugin_data[cc.PRIORITIES][cc.RENDER]
 
     def _run_merger(self, merger_name, data):
         """Assemble inputs for the named merger and run merge/dedup to get HTML"""
@@ -86,20 +86,21 @@ class main(core_base):
                 component = self.merger_loader.load(section_name)
             else:
                 component = self.plugin_loader.load(section_name, self.workspace)
-            if config_in.has_option(section_name, core_constants.CONFIGURE_PRIORITY):
-                priority = \
-                    config_in.getint(section_name, core_constants.CONFIGURE_PRIORITY)
+            # if input has a configure priority, use that
+            # otherwise, use default priority for the component
+            if config_in.has_option(section_name, cc.CONFIGURE_PRIORITY):
+                priority = config_in.getint(section_name, cc.CONFIGURE_PRIORITY)
             else:
                 priority = component.get_default_config_priority()
             components[section_name] = (component, priority)
-        self.logger.critical("{}".format(components))
         self.logger.debug('Configuring components in priority order')
         config_out = ConfigParser()
         order = 0
         for name in sorted(components, key=lambda x: components[x][1]):
             order += 1
-            component = components[name][0]
-            self.logger.debug('Configuring component {0} in order {1}'.format(name, order))
+            [component, priority] = components[name]
+            msg = 'Configuring {0}, priority {1}, order {2}'.format(name, priority, order)
+            self.logger.debug(msg)
             component.validate_minimal_config(config_in)
             config_tmp = component.configure(config_in)
             component.validate_full_config(config_tmp)
@@ -124,7 +125,7 @@ class main(core_base):
                 component = self.helper_loader.load(section_name, self.workspace)
             else:
                 component = self.plugin_loader.load(section_name, self.workspace)
-            priority = config.getint(section_name, core_constants.EXTRACT_PRIORITY)
+            priority = config.getint(section_name, cc.EXTRACT_PRIORITY)
             components[section_name] = (component, priority)
         self.logger.debug('Generating core data structure')
         data = core_extractor(self.log_level, self.log_path).run(config)
@@ -172,12 +173,12 @@ class main(core_base):
             body[plugin_name] = plugin.render(plugin_data)
             self.logger.debug("Ran plugin '{0}' for rendering".format(plugin_name))
             priorities[plugin_name] = self._get_render_priority(plugin_data)
-            attributes[plugin_name] = plugin_data[core_constants.ATTRIBUTES]
+            attributes[plugin_name] = plugin_data[cc.ATTRIBUTES]
         for (merger_name, merger_config) in data[self.MERGERS].items():
             body[merger_name] = self._run_merger(merger_name, data)
             self.logger.debug("Ran merger '{0}' for rendering".format(merger_name))
-            priorities[merger_name] = merger_config[core_constants.RENDER_PRIORITY]
-            attributes[merger_name] = merger_config[core_constants.ATTRIBUTES]
+            priorities[merger_name] = merger_config[cc.RENDER_PRIORITY]
+            attributes[merger_name] = merger_config[cc.ATTRIBUTES]
         self.logger.debug("Assembling HTML document")
         renderer = core_renderer(self.log_level, self.log_path)
         html = renderer.run(body, priorities, attributes, data) # TODO remove data argument

--- a/src/lib/djerba/core/main.py
+++ b/src/lib/djerba/core/main.py
@@ -92,6 +92,7 @@ class main(core_base):
             else:
                 priority = component.get_default_config_priority()
             components[section_name] = (component, priority)
+        self.logger.critical("{}".format(components))
         self.logger.debug('Configuring components in priority order')
         config_out = ConfigParser()
         order = 0
@@ -196,7 +197,7 @@ class main(core_base):
     def run(self, args):
         # run from command-line args
         # path validation was done in command-line script
-        ap = arg_processor(args, validate=False)
+        ap = arg_processor(args, self.logger, validate=False)
         mode = ap.get_mode()
         work_dir = ap.get_work_dir()
         if mode == constants.CONFIGURE:
@@ -241,14 +242,19 @@ class arg_processor(logger):
 
     DEFAULT_JSON_FILENAME = 'djerba_report.json'
 
-    def __init__(self, args, validate=True):
+    def __init__(self, args, logger=None, validate=True):
         self.args = args
-        self.log_level = self.get_args_log_level(self.args)
-        self.log_path = self.args.log_path
-        if self.log_path:
-            # we are verifying the log path, so don't write output there yet
-            path_validator(self.log_level).validate_output_file(self.log_path)
-        self.logger = self.get_logger(self.log_level, __name__, self.log_path)
+        if logger:
+            # do not call 'get_logger' if one has already been configured
+            # this way, we can preserve the level/path of an existing logger
+            self.logger = logger
+        else:
+            self.log_level = self.get_args_log_level(self.args)
+            self.log_path = self.args.log_path
+            if self.log_path:
+                # we are verifying the log path, so don't write output there yet
+                path_validator(self.log_level).validate_output_file(self.log_path)
+            self.logger = self.get_logger(self.log_level, __name__, self.log_path)
         if validate:
             self.validate_args(self.args)  # checks subparser and args are valid
         self.mode = self.args.subparser_name

--- a/src/lib/djerba/helpers/base.py
+++ b/src/lib/djerba/helpers/base.py
@@ -4,7 +4,7 @@ Cannot be used to create an object (abstract) but can be subclassed (base class)
 """
 
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from djerba.core.configure import configurable
 import djerba.core.constants as core_constants
 
@@ -19,12 +19,11 @@ class helper_base(configurable, ABC):
         # workspace is an instance of djerba.core.workspace
         super().__init__(**kwargs)
         self.workspace = kwargs['workspace']
-        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
-        self.set_all_ini_defaults(defaults)
         self.specify_params()
 
     # configure() method is defined in parent class
 
+    @abstractmethod
     def extract(self, config_section):
         """
         Input is a config section from a ConfigParser object
@@ -32,3 +31,7 @@ class helper_base(configurable, ABC):
         """
         msg = "Using placeholder method of parent class; does nothing"
         self.logger.debug(msg)
+
+    def set_priority_defaults(self, priority):
+        for key in self.PRIORITY_KEYS:
+            self.ini_defaults[key] = priority

--- a/src/lib/djerba/helpers/base.py
+++ b/src/lib/djerba/helpers/base.py
@@ -10,15 +10,18 @@ import djerba.core.constants as core_constants
 
 class helper_base(configurable, ABC):
 
+    PRIORITY_KEYS = [
+        core_constants.CONFIGURE_PRIORITY,
+        core_constants.EXTRACT_PRIORITY
+    ]
+
     def __init__(self, **kwargs):
         # workspace is an instance of djerba.core.workspace
         super().__init__(**kwargs)
         self.workspace = kwargs['workspace']
-        defaults = {
-            core_constants.CONFIGURE_PRIORITY: self.DEFAULT_CONFIG_PRIORITY,
-            core_constants.EXTRACT_PRIORITY: self.DEFAULT_CONFIG_PRIORITY,
-        }
+        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
         self.set_all_ini_defaults(defaults)
+        self.specify_params()
 
     # configure() method is defined in parent class
 

--- a/src/lib/djerba/helpers/base.py
+++ b/src/lib/djerba/helpers/base.py
@@ -13,7 +13,7 @@ class helper_base(configurable, ABC):
     PRIORITY_KEYS = [
         core_constants.CONFIGURE_PRIORITY,
         core_constants.EXTRACT_PRIORITY
-    ]
+    ]   # render priority is not defined for helpers
 
     def __init__(self, **kwargs):
         # workspace is an instance of djerba.core.workspace

--- a/src/lib/djerba/helpers/provenance_helper/helper.py
+++ b/src/lib/djerba/helpers/provenance_helper/helper.py
@@ -13,15 +13,11 @@ class main(helper_base):
     STUDY_TITLE = 'study_title'
     ROOT_SAMPLE_NAME = 'root_sample_name'
     PROVENANCE_OUTPUT = 'provenance_subset.tsv.gz'
-    DEFAULT_CONFIG_PRIORITY = 50
+    PRIORITY = 50
 
     # No automated configuration; use placeholder method of parent class
     # - uses study title and root sample name from core config
     # - provenance path must be configured manually (for now)
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.add_ini_required(self.PROVENANCE_INPUT)
 
     def extract(self, config):
         self.validate_full_config(config)
@@ -42,3 +38,8 @@ class main(helper_base):
                 if row[index.STUDY_TITLE] == study and row[index.ROOT_SAMPLE_NAME] == sample:
                     writer.writerow(row)
         self.logger.info('Finished reading file provenance from {0}'.format(provenance_path))
+
+    def specify_params(self):
+        self.logger.debug("Specifying params for provenance helper")
+        self.add_ini_required(self.PROVENANCE_INPUT)
+        self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/mergers/base.py
+++ b/src/lib/djerba/mergers/base.py
@@ -25,9 +25,6 @@ class merger_base(configurable, html_builder, ABC):
         super().__init__(**kwargs)
         schema_path = os.path.join(self.module_dir, self.SCHEMA_NAME)
         self.json_validator = json_validator(schema_path, self.log_level, self.log_path)
-        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
-        self.set_all_ini_defaults(defaults)
-        self.priority = 1000 # determines order of output for HTML; TODO FIXME use INI instead
         self.attributes = []
         self.specify_params()
 
@@ -40,16 +37,6 @@ class merger_base(configurable, html_builder, ABC):
             self.logger.error(msg)
             raise ValueError(msg)
         self.attributes = attributes
-
-    def get_priority(self):
-        return self.priority
-
-    def set_priority(self, priority):
-        if not isinstance(priority, int):
-            msg = "Priority value '{0}' is not an integer".format(priority)
-            self.logger.error(msg)
-            raise ValueError(msg)
-        self.priority = priority
 
     def merge_and_sort(self, inputs, sort_key):
         """
@@ -80,7 +67,12 @@ class merger_base(configurable, html_builder, ABC):
             self.json_validator.validate_data(item)
         return ''
 
+    def set_priority_defaults(self, priority):
+        for key in self.PRIORITY_KEYS:
+            self.ini_defaults[key] = priority
+
     def validate_inputs(self, inputs):
         for item in inputs:
             self.json_validator.validate_data(item)
         self.logger.info("All merger inputs validated")
+

--- a/src/lib/djerba/mergers/base.py
+++ b/src/lib/djerba/mergers/base.py
@@ -19,7 +19,7 @@ class merger_base(configurable, html_builder, ABC):
     PRIORITY_KEYS = [
         core_constants.CONFIGURE_PRIORITY,
         core_constants.RENDER_PRIORITY
-    ]
+    ] # extract priority is not defined for mergers
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/lib/djerba/mergers/base.py
+++ b/src/lib/djerba/mergers/base.py
@@ -16,17 +16,20 @@ class merger_base(configurable, html_builder, ABC):
 
     SCHEMA_NAME = 'merger_schema.json'
 
+    PRIORITY_KEYS = [
+        core_constants.CONFIGURE_PRIORITY,
+        core_constants.RENDER_PRIORITY
+    ]
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         schema_path = os.path.join(self.module_dir, self.SCHEMA_NAME)
         self.json_validator = json_validator(schema_path, self.log_level, self.log_path)
-        defaults = {
-            core_constants.CONFIGURE_PRIORITY: self.DEFAULT_CONFIG_PRIORITY,
-            core_constants.RENDER_PRIORITY: self.DEFAULT_CONFIG_PRIORITY
-        }
+        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
         self.set_all_ini_defaults(defaults)
         self.priority = 1000 # determines order of output for HTML; TODO FIXME use INI instead
         self.attributes = []
+        self.specify_params()
 
     def get_attributes(self):
         return self.attributes

--- a/src/lib/djerba/mergers/gene_information_merger/merger.py
+++ b/src/lib/djerba/mergers/gene_information_merger/merger.py
@@ -9,7 +9,7 @@ from djerba.mergers.base import merger_base
 
 class main(merger_base):
 
-    RENDER_PRIORITY = 300
+    PRIORITY = 300
     SCHEMA_FILENAME = 'gene_information_schema.json'
     SORT_KEY = 'Gene_URL'
 
@@ -20,9 +20,7 @@ class main(merger_base):
 
     def configure(self, config):
         config = self.apply_defaults(config)
-        wrapper = self.get_config_wrapper(config)
-        wrapper.set_my_param(core_constants.RENDER_PRIORITY, self.RENDER_PRIORITY)
-        return wrapper.get_config()
+        return config
 
     def table_header(self):
         names = [
@@ -59,3 +57,6 @@ class main(merger_base):
         html.append(self.TABLE_END)
         return "\n".join(html)
 
+    def specify_params(self):
+        self.logger.debug("Specifying params for gene_information_merger")
+        self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/mergers/gene_information_merger/test/merger_test.py
+++ b/src/lib/djerba/mergers/gene_information_merger/test/merger_test.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import unittest
+import djerba.core.constants as cc
 from configparser import ConfigParser
 from djerba.core.loaders import merger_loader
 from djerba.core.workspace import workspace
@@ -24,9 +25,11 @@ class TestGeneInformationMerger(TestBase):
             inputs = json.loads(json_file.read())
         loader = merger_loader(logging.WARNING)
         merger = loader.load(self.MODULE_NAME)
-        self.assertEqual(merger.get_priority(), 1000)
-        merger.set_priority(500)
-        self.assertEqual(merger.get_priority(), 500)
+        self.assertEqual(merger.ini_defaults.get(cc.CONFIGURE_PRIORITY), 300)
+        self.assertEqual(merger.ini_defaults.get(cc.RENDER_PRIORITY), 300)
+        merger.set_priority_defaults(500)
+        self.assertEqual(merger.ini_defaults.get(cc.CONFIGURE_PRIORITY), 500)
+        self.assertEqual(merger.ini_defaults.get(cc.RENDER_PRIORITY), 500)
         html = merger.render(inputs)
         md5_found = self.getMD5_of_string(html)
         self.assertEqual(md5_found, 'd436df8d05a8af3cbdf71a15eb12f7ea')

--- a/src/lib/djerba/plugins/base.py
+++ b/src/lib/djerba/plugins/base.py
@@ -12,12 +12,6 @@ import djerba.core.constants as core_constants
 
 class plugin_base(configurable, ABC):
 
-    PRIORITY_KEYS = [
-        core_constants.CONFIGURE_PRIORITY,
-        core_constants.EXTRACT_PRIORITY,
-        core_constants.RENDER_PRIORITY
-    ]
-
     def __init__(self, **kwargs):
         # workspace is an instance of djerba.core.workspace
         super().__init__(**kwargs)
@@ -54,5 +48,5 @@ class plugin_base(configurable, ABC):
         return ''
 
     def set_priority_defaults(self, priority):
-        for key in self.PRIORITY_KEYS:
+        for key in core_constants.PRIORITY_KEYS:
             self.ini_defaults[key] = priority

--- a/src/lib/djerba/plugins/base.py
+++ b/src/lib/djerba/plugins/base.py
@@ -23,8 +23,6 @@ class plugin_base(configurable, ABC):
         super().__init__(**kwargs)
         self.workspace = kwargs['workspace']
         self.json_validator = plugin_json_validator(self.log_level, self.log_path)
-        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
-        self.set_all_ini_defaults(defaults)
         self.specify_params()
 
     # configure() method is defined in parent class
@@ -54,3 +52,7 @@ class plugin_base(configurable, ABC):
         self.logger.debug(msg)
         self.json_validator.validate_data(data)
         return ''
+
+    def set_priority_defaults(self, priority):
+        for key in self.PRIORITY_KEYS:
+            self.ini_defaults[key] = priority

--- a/src/lib/djerba/plugins/base.py
+++ b/src/lib/djerba/plugins/base.py
@@ -12,17 +12,20 @@ import djerba.core.constants as core_constants
 
 class plugin_base(configurable, ABC):
 
+    PRIORITY_KEYS = [
+        core_constants.CONFIGURE_PRIORITY,
+        core_constants.EXTRACT_PRIORITY,
+        core_constants.RENDER_PRIORITY
+    ]
+
     def __init__(self, **kwargs):
         # workspace is an instance of djerba.core.workspace
         super().__init__(**kwargs)
         self.workspace = kwargs['workspace']
         self.json_validator = plugin_json_validator(self.log_level, self.log_path)
-        defaults = {
-            core_constants.CONFIGURE_PRIORITY: self.DEFAULT_CONFIG_PRIORITY,
-            core_constants.EXTRACT_PRIORITY: self.DEFAULT_CONFIG_PRIORITY,
-            core_constants.RENDER_PRIORITY: self.DEFAULT_CONFIG_PRIORITY
-        }
+        defaults = {k: self.DEFAULT_PRIORITY for k in self.PRIORITY_KEYS}
         self.set_all_ini_defaults(defaults)
+        self.specify_params()
 
     # configure() method is defined in parent class
 

--- a/src/lib/djerba/plugins/demo1/plugin.py
+++ b/src/lib/djerba/plugins/demo1/plugin.py
@@ -6,21 +6,14 @@ import djerba.core.constants as core_constants
 
 class main(plugin_base):
 
-    DEFAULT_CONFIG_PRIORITY = 100
+    PRIORITY = 100
     PLUGIN_VERSION = '1.0.0'
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.add_ini_required('question')
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
-        self.set_ini_default('dummy_file', None)
+    # __init__ is inherited from the parent class
 
     def configure(self, config):
         config = self.apply_defaults(config)
-        wrapper = self.get_config_wrapper(config)
-        wrapper.set_my_priorities(self.DEFAULT_CONFIG_PRIORITY)
-        return wrapper.get_config()
+        return config
 
     def extract(self, config):
         wrapper = self.get_config_wrapper(config)
@@ -54,3 +47,11 @@ class main(plugin_base):
     def render(self, data):
         super().render(data)  # validate against schema
         return "<h3>TODO demo1 plugin output goes here</h3>"
+
+    def specify_params(self):
+        self.logger.debug("Specifying params for plugin demo1")
+        self.add_ini_required('question')
+        self.set_ini_default(core_constants.CLINICAL, True)
+        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+        self.set_ini_default('dummy_file', None)
+        self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/plugins/demo2/plugin.py
+++ b/src/lib/djerba/plugins/demo2/plugin.py
@@ -6,21 +6,14 @@ import djerba.core.constants as core_constants
 
 class main(plugin_base):
 
-    DEFAULT_CONFIG_PRIORITY = 200
+    PRIORITY = 200
     PLUGIN_VERSION = '1.0.0'
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.add_ini_required('demo2_param')
-        self.set_ini_default('question', 'question.txt')
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+    # __init__ inherited from parent class
 
     def configure(self, config):
         config = self.apply_defaults(config)
-        wrapper = self.get_config_wrapper(config)
-        wrapper.set_my_priorities(self.DEFAULT_CONFIG_PRIORITY)
-        return wrapper.get_config()
+        return config
 
     def extract(self, config):
         wrapper = self.get_config_wrapper(config)
@@ -60,3 +53,11 @@ class main(plugin_base):
             "<h1>The Question is: {0}</h1>".format(data['results']['question'])
             ]
         return "\n".join(output)
+
+    def specify_params(self):
+        self.logger.debug("Specifying params for plugin demo2")
+        self.add_ini_required('demo2_param')
+        self.set_ini_default('question', 'question.txt')
+        self.set_ini_default(core_constants.CLINICAL, True)
+        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+        self.set_priority_defaults(self.PRIORITY)

--- a/src/test/core/config.ini
+++ b/src/test/core/config.ini
@@ -3,6 +3,7 @@
 [gene_information_merger]
 clinical = true
 supplementary = true
+configure_priority = 1000
 render_priority = 300
 
 [demo1]

--- a/src/test/core/generated.ini
+++ b/src/test/core/generated.ini
@@ -1,5 +1,8 @@
 [core]
 comment = comment goes here
+configure_priority = 0
+extract_priority = 0
+render_priority = 0
 
 [demo1]
 question = REQUIRED
@@ -26,7 +29,7 @@ extract_priority = 50
 
 [gene_information_merger]
 clinical = True
-configure_priority = 10000
-render_priority = 10000
+configure_priority = 300
+render_priority = 300
 supplementary = True
 

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -31,7 +31,7 @@ class TestCore(TestBase):
     LOREM_FILENAME = 'lorem.txt'
     SIMPLE_REPORT_JSON = 'simple_report_expected.json'
     SIMPLE_REPORT_MD5 = '66bf99e6ebe64d89bef09184953fd630'
-    SIMPLE_CONFIG_MD5 = 'c9130836e3ca5052383dc3e5b3844000'
+    SIMPLE_CONFIG_MD5 = '4cad62f56a7c7b71818e8bd83323de1f'
 
     def setUp(self):
         super().setUp() # includes tmp_dir

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -31,7 +31,7 @@ class TestCore(TestBase):
     LOREM_FILENAME = 'lorem.txt'
     SIMPLE_REPORT_JSON = 'simple_report_expected.json'
     SIMPLE_REPORT_MD5 = '66bf99e6ebe64d89bef09184953fd630'
-    SIMPLE_CONFIG_MD5 = '4cad62f56a7c7b71818e8bd83323de1f'
+    SIMPLE_CONFIG_MD5 = 'ca2002dadf718da0c80a6222e5eb4546'
 
     def setUp(self):
         super().setUp() # includes tmp_dir
@@ -209,7 +209,8 @@ class TestConfigValidation(TestCore):
             'baz': 'green',
             'fiz': 'purple'
         }
-        plugin.set_all_ini_defaults(defaults)
+        for k,v in defaults.items():
+            plugin.set_ini_default(k, v)
         config_3 = plugin.apply_defaults(config_3)
         self.assertEqual(config_3.get('demo1', 'baz'), 'green')
         self.assertEqual(config_3.get('demo1', 'fiz'), 'purple')
@@ -234,7 +235,8 @@ class TestConfigValidation(TestCore):
             '8 expected INI param(s) found for component demo1'
         self.assertIn(msg, log_context.output)
         # test setting all requirements
-        plugin.set_all_ini_required(['foo', 'bar'])
+        for x in ['foo', 'bar']:
+            plugin.add_ini_required(x)
         plugin.set_log_level(logging.CRITICAL)
         with self.assertRaises(DjerbaConfigError):
             plugin.validate_minimal_config(config)
@@ -419,16 +421,16 @@ class TestPriority(TestCore):
         djerba_main = main(self.tmp_dir, log_level=logging.WARNING)
         with self.assertLogs('djerba.core.main', level=logging.DEBUG) as log_context:
             config = djerba_main.configure(ini_path)
-        names_and_orders = [
-            ['core', 1],
-            ['demo1', 2],
-            ['demo2', 3],
-            ['gene_information_merger', 4]
+        priority_results = [
+            ['core', 0, 1],
+            ['demo1', 100, 2],
+            ['demo2', 200, 3],
+            ['gene_information_merger', 1000, 4]
         ]
-        prefix = 'DEBUG:djerba.core.main:'
-        template = '{0}Configuring component {1} in order {2}'
-        for (name, order) in names_and_orders:
-            msg = template.format(prefix, name, order)
+        prefix = 'DEBUG:djerba.core.main:Configuring'
+        template = '{0} {1}, priority {2}, order {3}'
+        for (name, priority, order) in priority_results:
+            msg = template.format(prefix, name, priority, order)
             self.assertIn(msg, log_context.output)
         # now give demo2 a higher priority than demo1
         config.set('demo1', core_constants.CONFIGURE_PRIORITY, '300')
@@ -438,14 +440,14 @@ class TestPriority(TestCore):
             config.write(out_file)
         with self.assertLogs('djerba.core.main', level=logging.DEBUG) as log_context:
             djerba_main.configure(ini_path_2)
-        names_and_orders = [
-            ['core', 1],
-            ['demo2', 2], # <---- changed order
-            ['demo1', 3],
-            ['gene_information_merger', 4]
+        priority_results = [
+            ['core', 0, 1],
+            ['demo2', 200, 2], # <---- changed order
+            ['demo1', 300, 3],
+            ['gene_information_merger', 1000, 4]
         ]
-        for (name, order) in names_and_orders:
-            msg = template.format(prefix, name, order)
+        for (name, priority, order) in priority_results:
+            msg = template.format(prefix, name, priority, order)
             self.assertIn(msg, log_context.output)
 
     def test_extract_priority(self):

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -285,13 +285,13 @@ class TestConfigWrapper(TestCore):
         os.environ[core_constants.DJERBA_DATA_DIR_VAR] = self.tmp_dir
         config = ConfigParser()
         config.read(os.path.join(self.test_source_dir, 'config_demo1.ini'))
-        wrapper = config_wrapper(config, 'demo1')
+        # wrapper issues warnings for DJERBA_{PRIVATE|TEST}_DIR, but this is OK
+        wrapper = config_wrapper(config, 'demo1', log_level=logging.ERROR)
         wrapper.apply_my_env_templates()
         expected = '{0}/not/a/file.txt'.format(self.tmp_dir)
         self.assertEqual(wrapper.get_my_string('dummy_file'), expected)
         if data_dir_orig != None:
             os.environ[core_constants.DJERBA_DATA_DIR_VAR] = data_dir_orig
-
 
 
 class TestIniGenerator(TestCore):


### PR DESCRIPTION
- Each plugin must have a `specify_params` method to define required and default INI parameters
- Using an INI parameter not defined in `specify_params` will cause an error
- Refactor INI and priority handling to enable `specify_params`
- Strict checking for environment variable substitution