### PR TITLE
Disallow dependency on mergers; update tests

### DIFF
--- a/src/lib/djerba/core/main.py
+++ b/src/lib/djerba/core/main.py
@@ -49,7 +49,6 @@ class main(core_base):
         self.plugin_loader = plugin_loader(self.log_level, self.log_path)
         self.merger_loader = merger_loader(self.log_level, self.log_path)
         self.helper_loader = helper_loader(self.log_level, self.log_path)
-
     def _get_render_priority(self, plugin_data):
         return plugin_data[cc.PRIORITIES][cc.RENDER]
 
@@ -85,6 +84,10 @@ class main(core_base):
             if len(depends)>0:
                 failed = 0
                 for dependency in depends:
+                    if self._is_merger_name(dependency):
+                        msg = "Cannot specify dependency on merger '{0}'".format(dependency)
+                        self.logger.error(msg)
+                        raise DjerbaDependencyError(msg)
                     dependency_ok = False
                     for other_name in ordered_names:
                         if other_name == name:

--- a/src/test/core/depends_configure_broken_3.ini
+++ b/src/test/core/depends_configure_broken_3.ini
@@ -1,0 +1,21 @@
+[core]
+
+[demo1]
+depends_configure = 
+question = How many roads must we each walk down?
+dummy_file = $DJERBA_DATA_DIR/not/a/file.txt
+
+[demo2]
+demo2_param = REQUIRED
+attributes = 
+clinical = True
+configure_priority = 200
+depends_configure = demo1,foo_merger
+depends_extract = 
+extract_priority = 200
+question = question.txt
+render_priority = 200
+supplementary = False
+
+[demo3]
+salutation = Klaatu barada nikto.

--- a/src/test/core/depends_extract_broken_3.ini
+++ b/src/test/core/depends_extract_broken_3.ini
@@ -1,0 +1,33 @@
+[core]
+attributes = 
+depends_configure = 
+depends_extract = 
+configure_priority = 0
+extract_priority = 0
+render_priority = 0
+comment = Djerba 1.0 under development
+
+[demo2]
+demo2_param = 42
+attributes = 
+clinical = True
+configure_priority = 100
+question = question.txt
+supplementary = False
+depends_configure = 
+depends_extract = 
+extract_priority = 500
+render_priority = 200
+
+[demo1]
+depends_configure = 
+configure_priority = 400
+question = What do you get if you multiply six by nine?
+dummy_file = $DJERBA_DATA_DIR/not/a/file.txt
+attributes = 
+depends_extract = demo2,foo_merger
+extract_priority = 100
+render_priority = 100
+clinical = True
+supplementary = False
+

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -70,7 +70,7 @@ class TestCore(TestBase):
         self.assert_report_MD5(html_string, self.SIMPLE_REPORT_MD5)
 
     def load_demo1_plugin(self):
-        loader = plugin_loader(log_level=logging.DEBUG)
+        loader = plugin_loader(log_level=logging.WARNING)
         plugin = loader.load('demo1', workspace(self.tmp_dir))
         return plugin
 
@@ -304,12 +304,11 @@ class TestDependencies(TestCore):
         html = None
         pdf = None
         args = self.mock_args(mode, work_dir, ini_path, out_path, json_path, html, pdf)
-        args.ini = os.path.join(self.test_source_dir, 'depends_configure_broken_1.ini')
-        with self.assertRaises(DjerbaDependencyError):
-            main(work_dir, log_level=logging.CRITICAL).run(args)
-        args.ini = os.path.join(self.test_source_dir, 'depends_configure_broken_2.ini')
-        with self.assertRaises(DjerbaDependencyError):
-            main(work_dir, log_level=logging.CRITICAL).run(args)
+        for num in [1,2,3]:
+            filename = 'depends_configure_broken_{0}.ini'.format(num)
+            args.ini = os.path.join(self.test_source_dir, filename)
+            with self.assertRaises(DjerbaDependencyError):
+                main(work_dir, log_level=logging.CRITICAL).run(args)
         args.ini = os.path.join(self.test_source_dir, 'depends_configure.ini')
         main(work_dir, log_level=logging.WARNING).run(args)
 
@@ -322,12 +321,11 @@ class TestDependencies(TestCore):
         html = None
         pdf = None
         args = self.mock_args(mode, work_dir, ini_path, out_path, json_path, html, pdf)
-        args.ini = os.path.join(self.test_source_dir, 'depends_extract_broken_1.ini')
-        with self.assertRaises(DjerbaDependencyError):
-            main(work_dir, log_level=logging.CRITICAL).run(args)
-        args.ini = os.path.join(self.test_source_dir, 'depends_extract_broken_2.ini')
-        with self.assertRaises(DjerbaDependencyError):
-            main(work_dir, log_level=logging.CRITICAL).run(args)
+        for num in [1,2,3]:
+            filename = 'depends_extract_broken_{0}.ini'.format(num)
+            args.ini = os.path.join(self.test_source_dir, filename)
+            with self.assertRaises(DjerbaDependencyError):
+                main(work_dir, log_level=logging.CRITICAL).run(args)
         args.ini = os.path.join(self.test_source_dir, 'depends_extract.ini')
         question_path = os.path.join(self.tmp_dir, 'question.txt')
         with open(question_path, 'w') as out_file:


### PR DESCRIPTION
Raise an error if a merger is specified in a dependency list