### PR TITLE
Represent attributes as a comma-separated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### GCGI-950: Attributes
+- Represent attributes as a comma-separated list, instead of individual parameters
+- Add a method to check all attributes are known
+- Define a list of known attributes in `configurable` class; may override in subclasses
+
 ### GCGI-951: Dependencies
 - Explicitly represent plugin dependencies with INI parameters
 - Params `depends_configure` and `depends_extract` expect a comma-separated list of component names, which will be checked at runtime

--- a/src/lib/djerba/core/base.py
+++ b/src/lib/djerba/core/base.py
@@ -1,5 +1,6 @@
 """Base class for Djerba core with shared methods/constants"""
 
+import csv
 import re
 
 from djerba.util.logger import logger
@@ -13,3 +14,12 @@ class base(logger):
     @staticmethod
     def _is_merger_name(name):
         return re.search('_merger$', name)
+
+    @staticmethod
+    def _parse_comma_separated_list(list_string):
+        # parse INI values stored as a comma-separated list -- eg. attributes, dependencies
+        # use CSV reader to allow escaping and handle other edge cases
+        # this method silently removes duplicates and sorts
+        parsed = next(csv.reader([list_string]))
+        parsed = sorted(list(set(parsed)))
+        return parsed

--- a/src/lib/djerba/core/constants.py
+++ b/src/lib/djerba/core/constants.py
@@ -33,6 +33,10 @@ CONFIGURE = 'configure'
 EXTRACT = 'extract'
 RENDER = 'render'
 
+# attribute names
+CLINICAL = 'clinical'
+SUPPLEMENTARY = 'supplementary'
+
 # core config elements
 DONOR = 'donor'
 PROJECT = 'project'

--- a/src/lib/djerba/core/extract.py
+++ b/src/lib/djerba/core/extract.py
@@ -19,18 +19,15 @@ class extractor(core_base):
         self.logger = self.get_logger(log_level, __name__, log_path)
         self.image_converter = converter(log_level, log_path)
 
-    def _get_merger_data(self, config):
+    def _get_merger_params(self, config):
         mergers = {}
         for section_name in config.sections():
             if self._is_merger_name(section_name):
                 merger_data = {}
                 merger_data[core_constants.RENDER_PRIORITY] = \
                     config.getint(section_name, core_constants.RENDER_PRIORITY)
-                attributes = []
-                for key in [core_constants.CLINICAL, core_constants.SUPPLEMENTARY]:
-                    if config.has_option(section_name, key) and \
-                       config.getboolean(section_name, key):
-                        attributes.append(key)
+                attributes_str = config.get(section_name, core_constants.ATTRIBUTES)
+                attributes = self._parse_comma_separated_list(attributes_str)
                 merger_data[core_constants.ATTRIBUTES] = attributes
                 mergers[section_name] = merger_data
         return mergers
@@ -83,6 +80,6 @@ class extractor(core_base):
             },
             'plugins': {},
         }
-        data['mergers'] = self._get_merger_data(config)
+        data['mergers'] = self._get_merger_params(config)
         data['comment'] = config['core']['comment']
         return data

--- a/src/lib/djerba/core/main.py
+++ b/src/lib/djerba/core/main.py
@@ -5,7 +5,6 @@ Main class to:
 - Merge and output results
 """
 from configparser import ConfigParser
-import csv
 import json
 import logging
 import os
@@ -62,11 +61,6 @@ class main(core_base):
         else:
             component = self.plugin_loader.load(name, self.workspace)
         return component
-
-    def _parse_comma_separated_list(self, list_string):
-        # parse INI values stored as a comma-separated list -- eg. attributes, dependencies
-        # use CSV reader to allow escaping and handle other edge cases
-        return next(csv.reader([list_string]))
 
     def _resolve_configure_dependencies(self, config, components, ordered_names):
         self._resolve_ini_deps(cc.DEPENDS_CONFIGURE, config, components, ordered_names)

--- a/src/lib/djerba/mergers/gene_information_merger/merger.py
+++ b/src/lib/djerba/mergers/gene_information_merger/merger.py
@@ -15,8 +15,6 @@ class main(merger_base):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, True)
 
     def configure(self, config):
         config = self.apply_defaults(config)
@@ -59,4 +57,5 @@ class main(merger_base):
 
     def specify_params(self):
         self.logger.debug("Specifying params for gene_information_merger")
+        self.set_ini_default(core_constants.ATTRIBUTES, 'clinical,supplementary')
         self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/plugins/demo1/plugin.py
+++ b/src/lib/djerba/plugins/demo1/plugin.py
@@ -17,11 +17,13 @@ class main(plugin_base):
 
     def extract(self, config):
         wrapper = self.get_config_wrapper(config)
+        attributes = wrapper.get_my_attributes()
+        self.check_attributes_known(attributes)
         data = {
             'plugin_name': self.identifier+' plugin',
             'version': self.PLUGIN_VERSION,
             'priorities': wrapper.get_my_priorities(),
-            'attributes': wrapper.get_my_attributes(),
+            'attributes': attributes,
             'merge_inputs': {
                 'gene_information_merger': [
                     {
@@ -51,7 +53,6 @@ class main(plugin_base):
     def specify_params(self):
         self.logger.debug("Specifying params for plugin demo1")
         self.add_ini_required('question')
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+        self.set_ini_default(core_constants.ATTRIBUTES, 'clinical')
         self.set_ini_default('dummy_file', None)
         self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/plugins/demo2/plugin.py
+++ b/src/lib/djerba/plugins/demo2/plugin.py
@@ -58,6 +58,5 @@ class main(plugin_base):
         self.logger.debug("Specifying params for plugin demo2")
         self.add_ini_required('demo2_param')
         self.set_ini_default('question', 'question.txt')
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+        self.set_ini_default(core_constants.ATTRIBUTES, 'clinical')
         self.set_priority_defaults(self.PRIORITY)

--- a/src/lib/djerba/plugins/demo3/plugin.py
+++ b/src/lib/djerba/plugins/demo3/plugin.py
@@ -35,6 +35,5 @@ class main(plugin_base):
     def specify_params(self):
         self.logger.debug("Specifying params for plugin demo2")
         self.add_ini_required('salutation')
-        self.set_ini_default(core_constants.CLINICAL, True)
-        self.set_ini_default(core_constants.SUPPLEMENTARY, False)
+        self.set_ini_default(core_constants.ATTRIBUTES, core_constants.CLINICAL)
         self.set_priority_defaults(self.PRIORITY)

--- a/src/test/core/config.ini
+++ b/src/test/core/config.ini
@@ -1,8 +1,6 @@
 [core]
 
 [gene_information_merger]
-clinical = true
-supplementary = true
 configure_priority = 1000
 render_priority = 300
 

--- a/src/test/core/config_demo1_expected.ini
+++ b/src/test/core/config_demo1_expected.ini
@@ -1,12 +1,10 @@
 [demo1]
 question = REQUIRED
-attributes = 
-clinical = True
+attributes = clinical
 configure_priority = 100
 depends_configure = 
 depends_extract = 
 dummy_file = None
 extract_priority = 100
 render_priority = 100
-supplementary = False
 

--- a/src/test/core/config_full.ini
+++ b/src/test/core/config_full.ini
@@ -2,17 +2,13 @@
 comment = Djerba 1.0 under development
 
 [gene_information_merger]
-clinical = true
-supplementary = true
-attributes = 
+attributes = clinical,supplementary
 depends_configure = 
 configure_priority = 300
 render_priority = 300
 
 [demo1]
-clinical = true
-supplementary = false
-attributes = 
+attributes = clinical
 depends_configure = 
 depends_extract = 
 configure_priority = 100
@@ -22,9 +18,7 @@ question = What do you get if you multiply six by nine?
 dummy_file = /path/of/dummy/file
 
 [demo2]
-clinical = true
-supplementary = false
-attributes = 
+attributes = clinical
 depends_configure = 
 depends_extract = 
 configure_priority = 200

--- a/src/test/core/depends_configure.ini
+++ b/src/test/core/depends_configure.ini
@@ -9,10 +9,8 @@ dummy_file = $DJERBA_DATA_DIR/not/a/file.txt
 [demo2]
 demo2_param = REQUIRED
 attributes = 
-clinical = True
 configure_priority = 100
 question = question.txt
-supplementary = False
 
 [demo3]
 salutation = Klaatu barada nikto.

--- a/src/test/core/depends_configure_broken_2.ini
+++ b/src/test/core/depends_configure_broken_2.ini
@@ -8,14 +8,12 @@ dummy_file = $DJERBA_DATA_DIR/not/a/file.txt
 [demo2]
 demo2_param = REQUIRED
 attributes = 
-clinical = True
 configure_priority = 200
 depends_configure = 
 depends_extract = 
 extract_priority = 200
 question = question.txt
 render_priority = 200
-supplementary = False
 
 [demo3]
 salutation = Klaatu barada nikto.

--- a/src/test/core/depends_configure_broken_3.ini
+++ b/src/test/core/depends_configure_broken_3.ini
@@ -8,14 +8,12 @@ dummy_file = $DJERBA_DATA_DIR/not/a/file.txt
 [demo2]
 demo2_param = REQUIRED
 attributes = 
-clinical = True
 configure_priority = 200
 depends_configure = demo1,foo_merger
 depends_extract = 
 extract_priority = 200
 question = question.txt
 render_priority = 200
-supplementary = False
 
 [demo3]
 salutation = Klaatu barada nikto.

--- a/src/test/core/depends_extract.ini
+++ b/src/test/core/depends_extract.ini
@@ -10,10 +10,8 @@ comment = Djerba 1.0 under development
 [demo2]
 demo2_param = 42
 attributes = 
-clinical = True
 configure_priority = 100
 question = question.txt
-supplementary = False
 depends_configure = 
 depends_extract = 
 extract_priority = 500
@@ -27,8 +25,6 @@ depends_configure =
 depends_extract = 
 extract_priority = 800
 render_priority = 800
-clinical = True
-supplementary = False
 
 [demo1]
 depends_configure = 
@@ -39,6 +35,4 @@ attributes =
 depends_extract = demo2,demo3
 extract_priority = 1000
 render_priority = 100
-clinical = True
-supplementary = False
 

--- a/src/test/core/depends_extract_broken_1.ini
+++ b/src/test/core/depends_extract_broken_1.ini
@@ -10,10 +10,8 @@ comment = Djerba 1.0 under development
 [demo2]
 demo2_param = 42
 attributes = 
-clinical = True
 configure_priority = 100
 question = question.txt
-supplementary = False
 depends_configure = 
 depends_extract = 
 extract_priority = 200
@@ -27,8 +25,6 @@ depends_configure =
 depends_extract = 
 extract_priority = 800
 render_priority = 800
-clinical = True
-supplementary = False
 
 [demo1]
 depends_configure = 
@@ -39,6 +35,4 @@ attributes =
 depends_extract = demo2,demo3
 extract_priority = 100
 render_priority = 100
-clinical = True
-supplementary = False
 

--- a/src/test/core/depends_extract_broken_2.ini
+++ b/src/test/core/depends_extract_broken_2.ini
@@ -10,10 +10,8 @@ comment = Djerba 1.0 under development
 [demo2]
 demo2_param = 42
 attributes = 
-clinical = True
 configure_priority = 100
 question = question.txt
-supplementary = False
 depends_configure = 
 depends_extract = 
 extract_priority = 500
@@ -28,6 +26,4 @@ attributes =
 depends_extract = demo2,demo3
 extract_priority = 100
 render_priority = 100
-clinical = True
-supplementary = False
 

--- a/src/test/core/depends_extract_broken_3.ini
+++ b/src/test/core/depends_extract_broken_3.ini
@@ -10,10 +10,8 @@ comment = Djerba 1.0 under development
 [demo2]
 demo2_param = 42
 attributes = 
-clinical = True
 configure_priority = 100
 question = question.txt
-supplementary = False
 depends_configure = 
 depends_extract = 
 extract_priority = 500
@@ -28,6 +26,4 @@ attributes =
 depends_extract = demo2,foo_merger
 extract_priority = 100
 render_priority = 100
-clinical = True
-supplementary = False
 

--- a/src/test/core/generated.ini
+++ b/src/test/core/generated.ini
@@ -9,27 +9,23 @@ render_priority = 0
 
 [demo1]
 question = REQUIRED
-attributes = 
-clinical = True
+attributes = clinical
 configure_priority = 100
 depends_configure = 
 depends_extract = 
 dummy_file = None
 extract_priority = 100
 render_priority = 100
-supplementary = False
 
 [demo2]
 demo2_param = REQUIRED
-attributes = 
-clinical = True
+attributes = clinical
 configure_priority = 200
 depends_configure = 
 depends_extract = 
 extract_priority = 200
 question = question.txt
 render_priority = 200
-supplementary = False
 
 [provenance_helper]
 provenance_input_path = REQUIRED
@@ -40,10 +36,8 @@ depends_extract =
 extract_priority = 50
 
 [gene_information_merger]
-attributes = 
-clinical = True
+attributes = clinical,supplementary
 configure_priority = 300
 depends_configure = 
 render_priority = 300
-supplementary = True
 


### PR DESCRIPTION
- Represent attributes as a comma-separated list, instead of individual parameters
- Add a method to check all attributes are known
- Define a list of known attributes in `configurable` class; may override in subclasses
