### PR TITLE
Tar dev get bc collapsed coverage

### DIFF
--- a/src/lib/djerba/plugins/tar/sample/constants.py
+++ b/src/lib/djerba/plugins/tar/sample/constants.py
@@ -6,6 +6,9 @@ KNOWN_VARIANTS = 'known_variants'
 CANCER_CONTENT = 'cancer_content'
 RAW_COVERAGE = 'raw_coverage'
 UNIQUE_COVERAGE = 'unique_coverage'
+COLLAPSED_COVERAGE_PL = 'collapsed_coverage_pl'
+COLLAPSED_COVERAGE_BC = 'collapsed_coverage_bc'
+PURITY = 'purity'
 
 # sample constants
 ASSAY = 'assay'

--- a/src/lib/djerba/plugins/tar/sample/plugin.py
+++ b/src/lib/djerba/plugins/tar/sample/plugin.py
@@ -35,6 +35,7 @@ class main(plugin_base):
         work_dir = self.workspace.get_work_dir()
         wrapper = self.get_config_wrapper(config)
         group_id = config[self.identifier]['group_id']
+        normal_id = config[self.identifier]['normal_id']
         if wrapper.my_param_is_null('purity'):
             ichorcna_metrics_file = provenance_tools.subset_provenance_sample(self, "ichorcna", group_id, "metrics\.json$")
             ichor_json = self.process_ichor_json(ichorcna_metrics_file) 
@@ -42,25 +43,36 @@ class main(plugin_base):
             purity = ichor_json["tumor_fraction"]
             self.write_purity(purity, work_dir)
             wrapper.set_my_param('purity', float('%.1E' % Decimal(purity*100)))
-        if wrapper.my_param_is_null('concensus_cruncher_file'):
-            wrapper.set_my_param('concensus_cruncher_file', provenance_tools.subset_provenance_sample(self, "consensusCruncher", group_id, "allUnique-hsMetrics\.HS\.txt$"))
+        if wrapper.my_param_is_null('consensus_cruncher_file'):
+            wrapper.set_my_param('consensus_cruncher_file', provenance_tools.subset_provenance_sample(self, "consensusCruncher", group_id, "allUnique-hsMetrics\.HS\.txt$"))
+        if wrapper.my_param_is_null('consensus_cruncher_file_normal'):
+            wrapper.set_my_param('consensus_cruncher_file_normal', provenance_tools.subset_provenance_sample(self, "consensusCruncher", normal_id, "allUnique-hsMetrics\.HS\.txt$"))
         if wrapper.my_param_is_null('raw_coverage'):
             qc_dict = self.fetch_coverage_etl_data(group_id)
             wrapper.set_my_param('raw_coverage', qc_dict['raw_coverage'])
+
+        # Get values for collapsed coverage for Pl and BC and put in config for QC reporting
+        if wrapper.my_param_is_null('collapsed_coverage_pl'):
+            wrapper.set_my_param('collapsed_coverage_pl', self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file']))
+        if wrapper.my_param_is_null('collapsed_coverage_bc'):
+            wrapper.set_my_param('collapsed_coverage_bc', self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file_normal']))
+        
         return config
     
     def extract(self, config):
         wrapper = self.get_config_wrapper(config)
         data = self.get_starting_plugin_data(wrapper, self.PLUGIN_VERSION)
-        unique_coverage = self.process_croncensus_cruncher(config[self.identifier]['concensus_cruncher_file'])
+        #unique_coverage = self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file'])
+        #collapsed_coverage_BC = self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file_normal']) 
         results =  {
                 "oncotree": config[self.identifier][constants.ONCOTREE],
                 "known_variants" : config[self.identifier][constants.KNOWN_VARIANTS],
-                "cancer_content" : float(config[self.identifier]['purity']),
+                "cancer_content" : float(config[self.identifier][constants.PURITY]),
                 "raw_coverage" : int(config[self.identifier][constants.RAW_COVERAGE]),
-                "unique_coverage" : unique_coverage,
+                "unique_coverage" : int(config[self.identifier][constants.COLLAPSED_COVERAGE_PL]),
                 "files": {
-                    "concensus_cruncher_file": config[self.identifier]['concensus_cruncher_file']
+                    "consensus_cruncher_file": config[self.identifier]['consensus_cruncher_file']
+                    #"consensus_cruncher_file_normal": config[self.identifier]['consensus_cruncher_file_normal'] # would need to edit testing to add this here but there are some issues
                 }
             }
         data['results'] = results
@@ -88,16 +100,16 @@ class main(plugin_base):
             ichor_json = json.load(ichor_results)
         return(ichor_json)
 
-    def process_croncensus_cruncher(self, concensus_cruncher_file):
+    def process_consensus_cruncher(self, consensus_cruncher_file):
         header_line = False
-        with open(concensus_cruncher_file, 'r') as cc_file:
+        with open(consensus_cruncher_file, 'r') as cc_file:
             reader_file = csv.reader(cc_file, delimiter="\t")
             for row in reader_file:
                 if row:
                     if row[0] == "BAIT_SET" :
                         header_line = True
                     elif header_line:
-                        unique_coverage = float(row[9])
+                        unique_coverage = float(row[9]) 
                         header_line = False
                     else:
                         next
@@ -106,6 +118,7 @@ class main(plugin_base):
     def specify_params(self):
         required = [
             'group_id',
+            'normal_id',
             'oncotree',
             'known_variants'
 
@@ -115,7 +128,10 @@ class main(plugin_base):
         discovered = [
             'purity',
             'raw_coverage',
-            'concensus_cruncher_file'
+            'consensus_cruncher_file',
+            'consensus_cruncher_file_normal',
+            'collapsed_coverage_pl',
+            'collapsed_coverage_bc'
         ]
         for key in discovered:
             self.add_ini_discovered(key)

--- a/src/lib/djerba/plugins/tar/sample/plugin.py
+++ b/src/lib/djerba/plugins/tar/sample/plugin.py
@@ -62,8 +62,6 @@ class main(plugin_base):
     def extract(self, config):
         wrapper = self.get_config_wrapper(config)
         data = self.get_starting_plugin_data(wrapper, self.PLUGIN_VERSION)
-        #unique_coverage = self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file'])
-        #collapsed_coverage_BC = self.process_consensus_cruncher(config[self.identifier]['consensus_cruncher_file_normal']) 
         results =  {
                 "oncotree": config[self.identifier][constants.ONCOTREE],
                 "known_variants" : config[self.identifier][constants.KNOWN_VARIANTS],
@@ -72,7 +70,6 @@ class main(plugin_base):
                 "unique_coverage" : int(config[self.identifier][constants.COLLAPSED_COVERAGE_PL]),
                 "files": {
                     "consensus_cruncher_file": config[self.identifier]['consensus_cruncher_file']
-                    #"consensus_cruncher_file_normal": config[self.identifier]['consensus_cruncher_file_normal'] # would need to edit testing to add this here but there are some issues
                 }
             }
         data['results'] = results

--- a/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
+++ b/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
@@ -40,9 +40,9 @@ class TestTarSamplePlugin(PluginTester):
         purity = ichor_json["tumor_fraction"]
         self.assertEqual(purity, 0.03978)
 
-    def test_process_croncensus_cruncher(self):
+    def test_process_consensus_cruncher(self):
         cc_expected_location = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.txt")
-        unique_coverage = sample.main.process_croncensus_cruncher(self, cc_expected_location)
+        unique_coverage = sample.main.process_consensus_cruncher(self, cc_expected_location)
         self.assertEqual(unique_coverage, 2088)
 
 if __name__ == '__main__':

--- a/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
+++ b/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
@@ -8,6 +8,7 @@ AUTHOR: Felix Beaudry
 import os
 import unittest
 import tempfile
+import shutil
 
 from djerba.util.validator import path_validator
 from djerba.plugins.plugin_tester import PluginTester
@@ -23,10 +24,16 @@ class TestTarSamplePlugin(PluginTester):
         self.tmp_dir = self.tmp.name
         sup_dir_var = 'DJERBA_TEST_DATA'
         self.sup_dir = os.environ.get(sup_dir_var)
+        self.consensus_cruncher_file = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.Pl.txt")
+        self.consensus_cruncher_file_normal = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.BC.txt")
 
     def testTarSample(self):
         test_source_dir = os.path.realpath(os.path.dirname(__file__))
         json_location = os.path.join(self.sup_dir ,"tar-plugin/report_json/tar.sample.json")
+                
+        shutil.copy(self.consensus_cruncher_file, test_source_dir)
+        shutil.copy(self.consensus_cruncher_file_normal, test_source_dir)
+
         params = {
             self.INI: 'tar.sample.ini',
             self.JSON: json_location,
@@ -40,10 +47,15 @@ class TestTarSamplePlugin(PluginTester):
         purity = ichor_json["tumor_fraction"]
         self.assertEqual(purity, 0.03978)
 
-    def test_process_consensus_cruncher(self):
-        cc_expected_location = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.txt")
+    def test_process_consensus_cruncher_Pl(self):
+        cc_expected_location = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.Pl.txt")
         unique_coverage = sample.main.process_consensus_cruncher(self, cc_expected_location)
         self.assertEqual(unique_coverage, 2088)
+    
+    def test_process_consensus_cruncher_BC(self):
+        cc_expected_location = os.path.join(self.sup_dir ,"tar-plugin/allUnique-hsMetrics.HS.BC.txt")
+        collapsed_coverage_bc = sample.main.process_consensus_cruncher(self, cc_expected_location)
+        self.assertEqual(collapsed_coverage_bc, 910)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/lib/djerba/plugins/tar/sample/test/tar.sample.ini
+++ b/src/lib/djerba/plugins/tar/sample/test/tar.sample.ini
@@ -7,6 +7,6 @@ oncotree=HGSOC
 known_variants=<em>TP53</em> (p.W91Ffs*53)
 purity=4.0
 raw_coverage=11000
-consensus_cruncher_file=/.mounts/labs/CGI/scratch/fbeaudry/reporting/djerba_test_data_lfs/tar-plugin/allUnique-hsMetrics.HS.txt
-consensus_cruncher_file_normal=/.mounts/labs/prod/vidarr/output-clinical/c78d/6592/5946/c78d65925946a95701e4d2ed58b7f2b70cb9c3ded70e24e82589191ec752fc22/allUnique-hsMetrics.HS.txt
+consensus_cruncher_file=allUnique-hsMetrics.HS.Pl.txt
+consensus_cruncher_file_normal=allUnique-hsMetrics.HS.BC.txt
 

--- a/src/lib/djerba/plugins/tar/sample/test/tar.sample.ini
+++ b/src/lib/djerba/plugins/tar/sample/test/tar.sample.ini
@@ -2,8 +2,11 @@
 	
 [tar.sample]
 group_id=REV-01-005_Pl
+normal_id=REV-01-005_BC
 oncotree=HGSOC
 known_variants=<em>TP53</em> (p.W91Ffs*53)
 purity=4.0
 raw_coverage=11000
-concensus_cruncher_file=/.mounts/labs/CGI/scratch/fbeaudry/reporting/djerba_test_data_lfs/tar-plugin/allUnique-hsMetrics.HS.txt
+consensus_cruncher_file=/.mounts/labs/CGI/scratch/fbeaudry/reporting/djerba_test_data_lfs/tar-plugin/allUnique-hsMetrics.HS.txt
+consensus_cruncher_file_normal=/.mounts/labs/prod/vidarr/output-clinical/c78d/6592/5946/c78d65925946a95701e4d2ed58b7f2b70cb9c3ded70e24e82589191ec752fc22/allUnique-hsMetrics.HS.txt
+


### PR DESCRIPTION
There were three spellings of "consensus": consensus, concensus, and cronsensus. So I made them all "consensus" (and changed the test data accordingly).

Added collapsed coverage BC and collapsed coverage Pl (also called unique coverage) to the ini, which meant moving that processing step to config. This is because both these values are required for TAR QC.

Outputs don't change, this is a change at the partial ini to full ini level.

I did not add the normal consensus cruncher file to the json because doing so would change testing data and the issue is that the Pl file and the BC file have the same name...there's some discussion there. So for now did not add it to json.

Passes testing.