### PR TITLE
Gcgi 1096 tar whizbam fix

### DIFF
--- a/src/lib/djerba/helpers/tar_input_params_helper/helper.py
+++ b/src/lib/djerba/helpers/tar_input_params_helper/helper.py
@@ -15,6 +15,7 @@ class main(helper_base):
     STUDY = 'study'
     PROJECT = 'project'
     ONCOTREE_CODE = 'oncotree_code'
+    CBIO_ID = 'cbio_id'
     PATIENT_STUDY_ID = 'patient_study_id'
     TUMOUR_ID = 'tumour_id'
     NORMAL_ID = 'normal_id'
@@ -40,6 +41,7 @@ class main(helper_base):
         self.add_ini_required(self.PROJECT)
         self.add_ini_required(self.STUDY)
         self.add_ini_required(self.ONCOTREE_CODE)
+        self.add_ini_required(self.CBIO_ID)
         self.add_ini_required(self.PATIENT_STUDY_ID)
         self.add_ini_required(self.TUMOUR_ID)
         self.add_ini_required(self.NORMAL_ID)
@@ -71,6 +73,7 @@ class main(helper_base):
             self.STUDY: config[self.identifier][self.STUDY],
             self.PROJECT: config[self.identifier][self.PROJECT],
             self.ONCOTREE_CODE: config[self.identifier][self.ONCOTREE_CODE],
+            self.CBIO_ID: config[self.identifier][self.CBIO_ID],
             self.PATIENT_STUDY_ID: config[self.identifier][self.PATIENT_STUDY_ID],
             self.TUMOUR_ID: config[self.identifier][self.TUMOUR_ID],
             self.NORMAL_ID: config[self.identifier][self.NORMAL_ID],

--- a/src/lib/djerba/helpers/tar_input_params_helper/test/data/helper.ini
+++ b/src/lib/djerba/helpers/tar_input_params_helper/test/data/helper.ini
@@ -1,11 +1,12 @@
 [core]
 
-[input_params_helper]
+[tar_input_params_helper]
 
 donor=REVOLVE_0003
 project=REVTAR
 study=Re-VOLVE
 oncotree_code=HGSOC
+cbio_id=REVOLVE
 patient_study_id=REV-01-003
 tumour_id=REV-01-003-Pl
 normal_id=REV-01-003-BC

--- a/src/lib/djerba/helpers/tar_input_params_helper/test/data/helper.json
+++ b/src/lib/djerba/helpers/tar_input_params_helper/test/data/helper.json
@@ -1,0 +1,20 @@
+{
+            "donor": "REVOLVE_0003",
+            "project": "REVTAR",
+            "study": "Re-VOLVE",
+            "oncotree_code": "HGSOC",
+            "cbio_id": "REVOLVE",
+            "patient_study_id": "REV-01-003",
+            "tumour_id": "REV-01-003-Pl",
+            "normal_id": "REV-01-003-BC",
+            "primary_cancer": "High grade serous ovarian carcinoma",
+            "site_of_biopsy": "Omentum",
+            "known_variants": "None",
+            "requisition_approved": "2023/03/28",
+            "assay": "TAR",
+            "attributes": "",
+            "depends_configure": "",
+            "depends_extract": "",
+            "configure_priority": "10",
+            "extract_priority": "10"
+}

--- a/src/lib/djerba/helpers/tar_input_params_helper/test/input_params.json
+++ b/src/lib/djerba/helpers/tar_input_params_helper/test/input_params.json
@@ -1,1 +1,0 @@
-{"donor": "REVOLVE_0003", "study": "Re-VOLVE", "project": "REVTAR", "oncotree_code": "HGSOC", "patient_study_id": "REV-01-003", "tumour_id": "REV-01-003-Pl", "normal_id": "REV-01-003-BC", "primary_cancer": "High grade serous ovarian carcinoma", "site_of_biopsy": "Omentum", "known_variants": "None", "requisition_approved": "2023/03/28", "assay": "TAR"}

--- a/src/lib/djerba/plugins/tar/snv_indel/plugin.py
+++ b/src/lib/djerba/plugins/tar/snv_indel/plugin.py
@@ -34,9 +34,9 @@ class main(plugin_base):
            'donor',
            'oncotree_code',
            'assay',
+           'cbio_id',
            'tumour_id',
            'normal_id',
-           'project',
            'maf_file',
            'maf_file_normal',
       ]
@@ -60,12 +60,12 @@ class main(plugin_base):
           wrapper.set_my_param('assay', input_data['assay'])
       if wrapper.my_param_is_null('oncotree_code'):
           wrapper.set_my_param('oncotree_code', input_data['oncotree_code'])
+      if wrapper.my_param_is_null('cbio_id'):
+          wrapper.set_my_param('cbio_id', input_data['cbio_id'])
       if wrapper.my_param_is_null('tumour_id'):
           wrapper.set_my_param('tumour_id', input_data['tumour_id'])
       if wrapper.my_param_is_null('normal_id'):
           wrapper.set_my_param('normal_id', input_data['normal_id'])
-      if wrapper.my_param_is_null('project'):
-          wrapper.set_my_param('project', input_data['project'])
       
       # SECOND PASS: get files
       if wrapper.my_param_is_null('maf_file'):
@@ -81,8 +81,8 @@ class main(plugin_base):
       work_dir = self.workspace.get_work_dir()
 
       # Get any input parameters
-      project = config[self.identifier]["project"]
       oncotree_code = config[self.identifier]["oncotree_code"]
+      cbio_id = config[self.identifier]["cbio_id"]
       tumour_id = config[self.identifier]["tumour_id"]
       normal_id = config[self.identifier]["normal_id"]
       assay = config[self.identifier]["assay"]
@@ -96,7 +96,7 @@ class main(plugin_base):
       
       # Preprocessing
       maf_file = self.filter_maf_for_tar(work_dir, config[self.identifier]["maf_file"], config[self.identifier]["maf_file_normal"])
-      preprocess(config, work_dir, assay, project, oncotree_code, tumour_id, normal_id, maf_file).run_R_code()
+      preprocess(config, work_dir, assay, oncotree_code, cbio_id, tumour_id, normal_id, maf_file).run_R_code()
       
       mutations_file = os.path.join(work_dir, sic.MUTATIONS_EXTENDED)
       mutations_extended_file = os.path.join(work_dir, sic.MUTATIONS_EXTENDED_ONCOGENIC)

--- a/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/Rscripts/process_data.r
+++ b/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/Rscripts/process_data.r
@@ -14,7 +14,7 @@ option_list = list(
   make_option(c("-u", "--whizbam_url"), type="character", default="https://whizbam.oicr.on.ca", help="whizbam url", metavar="character"),
   make_option(c("-w", "--tumourid"), type="character", default=NULL, help="whizbam tumour name", metavar="character"),
   make_option(c("-x", "--normalid"), type="character", default=NULL, help="whizbam normal name", metavar="character"),
-  make_option(c("-y", "--seqtype"), type="character", default="GENOME", help="sequencing type", metavar="character"),
+  make_option(c("-y", "--seqtype"), type="character", default="EXOME", help="sequencing type", metavar="character"),
   make_option(c("-z", "--genome"), type="character", default="hg38", help="genome version", metavar="character"),
   make_option(c("-T", "--tar"), type="character", default=FALSE, help="true or false value for tar assay", metavar="boolean")
 )

--- a/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/preprocess.py
+++ b/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/preprocess.py
@@ -66,7 +66,7 @@ class preprocess(logger):
   MAX_UNMATCHED_GNOMAD_AF = 0.001
 
 
-  def __init__(self, config, work_dir, assay, study, oncotree_code, tumour_id, normal_id, maf_file, log_level=logging.DEBUG, log_path=None):
+  def __init__(self, config, work_dir, assay, oncotree_code, cbio_id, tumour_id, normal_id, maf_file, log_level=logging.DEBUG, log_path=None):
       
       # CONFIG
       self.config = config
@@ -92,9 +92,9 @@ class preprocess(logger):
       # PARAMETERS
       self.assay = assay
       self.oncotree_code = oncotree_code
+      self.cbio_id = cbio_id
       self.tumour_id = tumour_id
       self.normal_id = normal_id
-      self.study = study
       self.maf_file = maf_file
       self.maf_file_normal = self.config['tar.snv_indel']['maf_file_normal']
 
@@ -110,7 +110,7 @@ class preprocess(logger):
      '--whizbam_url', 'https://whizbam.oicr.on.ca',
      '--tumourid', self.tumour_id,
      '--normalid', self.normal_id,
-     '--cbiostudy', self.study,
+     '--cbiostudy', self.cbio_id,
      '--maffile', maf_path,
      '--tar', 'TRUE'
     ]

--- a/src/lib/djerba/plugins/tar/snv_indel/test/data/tar_snv_indel.ini
+++ b/src/lib/djerba/plugins/tar/snv_indel/test/data/tar_snv_indel.ini
@@ -2,7 +2,7 @@
 
 [tar.snv_indel]
 donor=REVOLVE_0005
-project=REVTAR
+cbio_id=REVOLVE
 assay=TAR
 maf_file=$DJERBA_TEST_DATA/snv-indel-plugin/REVOLVE_0005_Pl_T_TS_REV-01-005_Pl.merged.maf.gz
 maf_file_normal= $DJERBA_TEST_DATA/snv-indel-plugin/REVOLVE_0005_Ly_R_TS_REV-01-005_BC.merged.maf.gz


### PR DESCRIPTION
Small fix to make it so that we don't have to manually change whizbam links for viewing

- cbio_id is now a required parameter in tar_input_params_helper and in the snv_indel plugin
- changed genome to exome in whizbam link maker function

Snv indel test passes, no need to update bitbucket