### PR TITLE
Fixed failed report plugin 

### DIFF
--- a/src/lib/djerba/plugins/failed_report/plugin.py
+++ b/src/lib/djerba/plugins/failed_report/plugin.py
@@ -15,7 +15,7 @@ from djerba.core.workspace import workspace
 class main(plugin_base):
 
     PRIORITY = 600
-    PLUGIN_VERSION = '0.1'
+    PLUGIN_VERSION = '1.0.0'
     MAKO_TEMPLATE_NAME = 'failed_report_template.html'
     FAILED_TEMPLATE_FILE = 'failed_template.txt'
     FAILED_FILE = 'failed_file'

--- a/src/lib/djerba/plugins/failed_report/plugin.py
+++ b/src/lib/djerba/plugins/failed_report/plugin.py
@@ -14,7 +14,7 @@ from djerba.core.workspace import workspace
 
 class main(plugin_base):
 
-    PRIORITY = 100
+    PRIORITY = 600
     PLUGIN_VERSION = '0.1'
     MAKO_TEMPLATE_NAME = 'failed_report_template.html'
     FAILED_TEMPLATE_FILE = 'failed_template.txt'

--- a/src/test/test_env.sh
+++ b/src/test/test_env.sh
@@ -4,7 +4,7 @@
 # assumes djerba and djerba_test_data are in ~/git
 # update module and filename as necessary for additional dev releases
 
-module load djerba/1.0.0-dev18
+module load djerba
 export PYTHONPATH=${HOME}/git/djerba/src/lib:$PYTHONPATH
 export PATH=${HOME}/git/djerba/src/bin:$PATH
 export DJERBA_BASE_DIR=${HOME}/git/djerba/src/lib/djerba


### PR DESCRIPTION
Incremented failed report plugin priority so that the failed report is in the correct order
Also renamed test_env.sh so that it doesn't refer to a specific dev version and doesn't need to keep being changed