### PR TITLE
Removed page break before sign offs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 - GCGI-1233: allowed support for purity and ploidy to be "NA", changed failed report template text 
 - Fixed unit tests for various plugins
+- Changed sign-offs page break to "auto" 
 
 ## v1.1.1: 2023-12-13
 

--- a/src/lib/djerba/core/html/clinical_footer.html
+++ b/src/lib/djerba/core/html/clinical_footer.html
@@ -3,8 +3,9 @@
   from time import strftime
 %>
 
+<br>
 
-<hr class="header-big-line" style="width:100%; align:right; page-break-before:always;">
+<hr class="header-big-line" style="width:100%; align:right; page-break-before:auto">
 
 <h2>Report Sign-offs</h2>
 

--- a/src/lib/djerba/plugins/case_overview/test/plugin_test.py
+++ b/src/lib/djerba/plugins/case_overview/test/plugin_test.py
@@ -32,7 +32,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_WGTS.ini',
             self.JSON: json_location,
-            self.MD5: '7ca69fb48132371b2eb44e155caf45fe'
+            self.MD5: '7532366678d57cc4ac51ac790cc3f902'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -43,7 +43,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_TAR.ini',
             self.JSON: json_location,
-            self.MD5: '28efb7d0c9bc16a672990c0ca1451a5d'
+            self.MD5: '08627c99b146c91c034f56c90563570b'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/cnv/test/plugin_test.py
+++ b/src/lib/djerba/plugins/cnv/test/plugin_test.py
@@ -43,7 +43,7 @@ class TestWgtsCnv(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: self.JSON_NAME,
-            self.MD5: '84df608a34052efa8f2f89c5cfd6d80e'
+            self.MD5: 'd5a5725c6097228b6aefffdc4521cc03'
         }
         self.run_basic_test(input_dir, params, work_dir=work_dir)
 

--- a/src/lib/djerba/plugins/demo1/test/plugin_test.py
+++ b/src/lib/djerba/plugins/demo1/test/plugin_test.py
@@ -13,7 +13,7 @@ class TestDemo1(PluginTester):
         params = {
             self.INI: 'demo_1.ini',
             self.JSON: 'demo_1.json',
-            self.MD5: '1d6aa4e7b94b42c788f84f4e5ea8875f'
+            self.MD5: '9aaa43ddde3e4ac53b9d15b7eb43df7a'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/demo2/test/plugin_test.py
+++ b/src/lib/djerba/plugins/demo2/test/plugin_test.py
@@ -15,7 +15,7 @@ class TestDemo2(PluginTester):
         params = {
             self.INI: 'demo_2.ini',
             self.JSON: 'demo_2.json',
-            self.MD5: '9f0b9018b27a40c5907c2acf797f7e54'
+            self.MD5: 'ad90ea05fe818f9fb67028b7c8707526'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/demo3/test/plugin_test.py
+++ b/src/lib/djerba/plugins/demo3/test/plugin_test.py
@@ -13,7 +13,7 @@ class TestDemo3(PluginTester):
         params = {
             self.INI: 'demo_3.ini',
             self.JSON: 'demo_3.json',
-            self.MD5: 'b3b6a08b6b66b7a9984beef4eb8e96ec'
+            self.MD5: '006ed3771a31cfdc689a21cf877dff5d'
         }
         self.run_basic_test(test_source_dir, params, 'demo3')
 

--- a/src/lib/djerba/plugins/failed_report/test/plugin_test.py
+++ b/src/lib/djerba/plugins/failed_report/test/plugin_test.py
@@ -23,7 +23,7 @@ class TestFailedReportPlugin(PluginTester):
         params = {
             self.INI: 'failed_report.ini',
             self.JSON: json_location,
-            self.MD5: '8c28f387b1487900f3eea3be2ad521f9'
+            self.MD5: 'fb99e52942e6ef66c710d848c45a7f48'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/fusion/test/plugin_test.py
+++ b/src/lib/djerba/plugins/fusion/test/plugin_test.py
@@ -47,7 +47,7 @@ class TestFusion(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: self.JSON_NAME,
-            self.MD5: 'fb78d5970ae0613d5ec65e24c1a23cf6'
+            self.MD5: 'b94db51a37dd9b51880bf8b3cf39da03'
         }
         self.run_basic_test(input_dir, params, 'fusion', logging.ERROR, work_dir)
 

--- a/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
+++ b/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
@@ -51,7 +51,7 @@ class TestGenomicLandscapePlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: '53613e154d1e0008376c6fe6d0174760'
+            self.MD5: '42bee95bf7f8b3c4409c1c7720647a51'
         }
         self.run_basic_test(input_dir, params)
 

--- a/src/lib/djerba/plugins/sample/test/plugin_test.py
+++ b/src/lib/djerba/plugins/sample/test/plugin_test.py
@@ -31,7 +31,7 @@ class TestWgtsSamplePlugin(PluginTester):
         params = {
             self.INI: ini_location,
             self.JSON: json_location,
-            self.MD5: '3000449df1bac887f778278221776e03'
+            self.MD5: 'f23dbf3e5ac417740bcbb990723db0f0'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -46,7 +46,7 @@ class TestWgtsSamplePlugin(PluginTester):
         params = {
             self.INI: ini_location,
             self.JSON: json_location,
-            self.MD5: '35fce62d7d85272abfabe16f7d5dfc00'
+            self.MD5: 'c9b5dd13be0f6d947550d93cd165b64f'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/summary/test/plugin_test.py
+++ b/src/lib/djerba/plugins/summary/test/plugin_test.py
@@ -24,7 +24,7 @@ class TestSummaryPlugin(PluginTester):
         params = {
             self.INI: 'summary.ini',
             self.JSON: json_location,
-            self.MD5: '0245b24892cc137aa40f92b5114bc79e'
+            self.MD5: '2019ab441f76d19c1090b4218f4d9654'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/supplement/body/resources/PWGS.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/PWGS.disclaimer.html
@@ -5,3 +5,4 @@ Gene annotation is not performed in this assay and variants are not classified (
 <br>This test was developed and its performance characteristics determined by OICR Genomics. 
 It has not been cleared or approved by the US Food and Drug Administration.
 </p>
+<br>

--- a/src/lib/djerba/plugins/supplement/body/resources/TAR.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/TAR.disclaimer.html
@@ -2,4 +2,5 @@
   FOR sWGS, The sensitivity is 74.2% and the specificity is 99.4% when recalling amplifications from a Tumour / Normal pair in shallow whole genome sequencing. The limit of detection is &#8805; 1.4-fold change for gene amplifications in a 10% tumour purity. 
   FOR SNV/INDEL, The sensitivity and specificity for FFPE samples is 95.5% and 94.1%. For cfDNA samples the sensitivity is 84% and the specificity is 97%. The limit of detection was determined to be 1% at a minimum collapsed coverage of 400x, with at least 3 supporting reads.
   This test was developed and its performance characteristics determined by OICR Genomics. It has not been cleared or approved by the US Food and Drug Administration.
-</p>   
+</p>  
+<br>

--- a/src/lib/djerba/plugins/supplement/body/resources/WGS.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/WGS.disclaimer.html
@@ -2,3 +2,4 @@
     The sensitivity for CNVs and RNA fusions is 86% and 32%, respectively. 
     The limit of detection is 10% VAF for SNVs and 20% for in/dels. The limit of detection for MSI is cellularity >50%.</p>
 <p>This test was developed and its performance characteristics determined by OICR Genomics. It has not been cleared or approved by the US Food and Drug Administration.</p>
+<br>

--- a/src/lib/djerba/plugins/supplement/body/resources/WGS40X.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/WGS40X.disclaimer.html
@@ -1,2 +1,3 @@
 <p>Based on a minimum tumour purity of 65%, the sensitivity for SNVs and in/dels is 96% and 77.7%, respectively. The sensitivity for CNVs and RNA fusions is 96.3% and 32%, respectively. The limit of detection is 10% VAF for SNVs and 20% for in/dels. The limit of detection for MSI is cellularity >50%.</p>
 <p>This test was developed and its performance characteristics determined by OICR Genomics. It has not been cleared or approved by the US Food and Drug Administration.</p>
+<br>

--- a/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
+++ b/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
@@ -24,7 +24,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'PWGS.supp.ini',
             self.JSON: json_location,
-            self.MD5: '9980b0f7f92c6e51f6928ce852a33b0d'
+            self.MD5: 'fd054f23b5f42c61a945744e7ff94e80'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -34,7 +34,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'TAR.supp.ini',
             self.JSON: json_location,
-            self.MD5: '7e899cd598fcf52ba126ba91a1d5c234'
+            self.MD5: '28dd289019d22b26a64ede1e7696a5e8'
         }
         self.run_basic_test(test_source_dir, params)
    
@@ -44,7 +44,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'TAR.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'f42de9c16acee44016cef3cbbf4b4d94'
+            self.MD5: 'bcf382aa82a01573bdbd1f7473c161ce'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -54,7 +54,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.supp.ini',
             self.JSON: json_location,
-            self.MD5: '189fb556a113e51d3c9eb52d272892ae'
+            self.MD5: '39c481b7812e253a0bd6e88ea5e0f5ec'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -64,7 +64,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '94fddd6ebd7456294457ddcafa4e084a'
+            self.MD5: '6a8607d8343d72b0272f149fc348963b'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -74,7 +74,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.supp.ini',
             self.JSON: json_location,
-            self.MD5: '3b60dd5df4836f56b8255ae9c69706aa'
+            self.MD5: 'ccaf67e3e9a6ea59c69dbfc2bba69bca'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -84,7 +84,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '5f8209c64606b24855295a61bb7f52ed'
+            self.MD5: 'e2292261e4048d1ea70878e33f96b184'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/supplement/header/test/plugin_test.py
+++ b/src/lib/djerba/plugins/supplement/header/test/plugin_test.py
@@ -13,7 +13,7 @@ class TestHeader(PluginTester):
         params = {
             self.INI: 'header.ini',
             self.JSON: 'header.json',
-            self.MD5: '024e312a83588510dd1fe8ad6cfc0891'
+            self.MD5: 'd3c67d645b5035e6ac792f62e9b52813'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
+++ b/src/lib/djerba/plugins/tar/sample/test/plugin_test.py
@@ -38,7 +38,7 @@ class TestTarSamplePlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: 'eebb83aa8e6d8a01781e5736de5c8d21'
+            self.MD5: '34d2d193bde3cd6fb3174c5d559cb736'
         }
         self.run_basic_test(input_dir, params)
 

--- a/src/lib/djerba/plugins/tar/snv_indel/test/plugin_test.py
+++ b/src/lib/djerba/plugins/tar/snv_indel/test/plugin_test.py
@@ -52,7 +52,7 @@ class TestTarSNVIndelPlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: '3f5be530080ea7b740478e0dd7bb582f'
+            self.MD5: 'd9dc0fc1e1f56bcf29f682db7cd714fa'
         }
         self.run_basic_test(input_dir, params)
 
@@ -78,7 +78,7 @@ class TestTarSNVIndelPlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: '12bfd60437ade3d9356b4542e2d07dc3'
+            self.MD5: '59302c96b44604af17eecbacb97200d4'
         }
         self.run_basic_test(input_dir, params)
 

--- a/src/lib/djerba/plugins/tar/swgs/test/plugin_test.py
+++ b/src/lib/djerba/plugins/tar/swgs/test/plugin_test.py
@@ -48,7 +48,7 @@ class TestTarSwgsPlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: '97000042e1dd447fc3521c03f19f2060'
+            self.MD5: '786dab113b69aa670ed530404bf263c2'
         }
         self.run_basic_test(input_dir, params)
 
@@ -73,7 +73,7 @@ class TestTarSwgsPlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: json_location,
-            self.MD5: '031eb01e68e29a18b8dc36873ab7700d'
+            self.MD5: 'd988d19d0ebd1f9fd897f0a3eae67d4f'
         }
         self.run_basic_test(input_dir, params)
     

--- a/src/lib/djerba/plugins/wgts/snv_indel/test/plugin_test.py
+++ b/src/lib/djerba/plugins/wgts/snv_indel/test/plugin_test.py
@@ -46,7 +46,7 @@ class TestSnvIndelPlugin(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: self.JSON_NAME,
-            self.MD5: '6aba58af1109d0a0d8a9a2f9417e1508'
+            self.MD5: '63006c5c941a03e1e249346b0fd7db0b'
         }
         self.run_basic_test(input_dir, params, work_dir=work_dir)
 

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -30,7 +30,7 @@ class TestCore(TestBase):
 
     LOREM_FILENAME = 'lorem.txt'
     SIMPLE_REPORT_JSON = 'simple_report_expected.json'
-    SIMPLE_REPORT_MD5 = '904bffdedff29e9ca16872d45ed12d21'
+    SIMPLE_REPORT_MD5 = 'f78e83206c5c12b989e1cee69503ffce'
     SIMPLE_CONFIG_MD5 = 'ab4b71b790f2b12aa802b8eaa1658951'
 
     class mock_args:


### PR DESCRIPTION
Removed page break before sign offs
Added whitespace before sign offs by adding br to various disclaimers
This caused a cascade of having to fix md5 sums for all the tests which I also did 
All tests pass:

```
./src/test/core/test_core.py
python3 -m unittest discover -s src/lib/djerba  -p "plugin_test.py" -v
python3 -m unittest discover -s src/lib/djerba  -p "helper_test.py" -v
python3 -m unittest discover -s src/lib/djerba  -p "merger_test.py" -v
```