### PR TITLE
Removed quality failure text from failed report plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - GCGI-1217: Remove NORMAL_DEPTH variable  
 - GCGI-1194: Research Report PDF Footer says RUO 
 - GCGI-1261: Update plugin tester base class, so it is unaffected by changes in core HTML
+- removed "Quality Failure" text in failed report plugin html
 
 ### Improvements for mini-Djerba
 

--- a/src/lib/djerba/plugins/failed_report/failed_report_template.html
+++ b/src/lib/djerba/plugins/failed_report/failed_report_template.html
@@ -8,8 +8,6 @@
   <!-- results summary -->
   ${html_builder().section_cells_begin("<h2>Results Summary</h2>","main")}
 
-  <h2>Quality Failure</h2>
-
   <p style="border-width:3px; border-style:solid; border-color:#FF0000; padding: 1em;" ${html_builder().markdown_to_html(FAILED_TEXT)}</p>
   
   <br>

--- a/src/lib/djerba/plugins/failed_report/test/plugin_test.py
+++ b/src/lib/djerba/plugins/failed_report/test/plugin_test.py
@@ -23,7 +23,7 @@ class TestFailedReportPlugin(PluginTester):
         params = {
             self.INI: 'failed_report.ini',
             self.JSON: json_location,
-            self.MD5: '7282fdbbc16e3230be229a40093e53d1'
+            self.MD5: 'dfa151e2995503bccde5ad9ae6e31e91'
         }
         self.run_basic_test(test_source_dir, params)
 


### PR DESCRIPTION
Failed report plugin test passes
Generated example report and it looks as desired