### PR TITLE
Added BIOTYPE = protein_coding to maf filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- GCGI-1363: excluded all but protein coding variants from maf filtering (BIOTYPE = protein_coding)
+
 ## v.1.5.6: 2024-05-06
 - Fix to TERT protein annotation (G>A -> C>T)
 - Removed extra white space in gene information section

--- a/src/lib/djerba/plugins/wgts/snv_indel/constants.py
+++ b/src/lib/djerba/plugins/wgts/snv_indel/constants.py
@@ -16,6 +16,7 @@ FILTER = 'FILTER'
 T_DEPTH = 't_depth'
 T_ALT_COUNT = 't_alt_count'
 GNOMAD_AF = 'gnomAD_AF'
+BIOTYPE = 'BIOTYPE'
 HUGO_SYMBOL = 'Hugo_Symbol'
 CHROMOSOME = 'Chromosome'
 START = 'Start_Position'
@@ -29,6 +30,7 @@ MAF_KEYS = [
     T_DEPTH,
     T_ALT_COUNT,
     GNOMAD_AF,
+    BIOTYPE,
     HUGO_SYMBOL,
     CHROMOSOME,
     START,

--- a/src/lib/djerba/plugins/wgts/snv_indel/tools.py
+++ b/src/lib/djerba/plugins/wgts/snv_indel/tools.py
@@ -67,6 +67,7 @@ class snv_indel_processor(logger):
         row_t_depth = int(row[ix.get(sic.T_DEPTH)])
         alt_count_raw = row[ix.get(sic.T_ALT_COUNT)]
         gnomad_af_raw = row[ix.get(sic.GNOMAD_AF)]
+        biotype = row[ix.get(sic.BIOTYPE)]
         row_t_alt_count = float(alt_count_raw) if alt_count_raw!='' else 0.0
         row_gnomad_af = float(gnomad_af_raw) if gnomad_af_raw!='' else 0.0
         is_matched = row[ix.get(sic.MATCHED_NORM_SAMPLE_BARCODE)] != 'unmatched'
@@ -77,6 +78,7 @@ class snv_indel_processor(logger):
         if row_t_depth >= 1 and \
            row_t_alt_count/row_t_depth >= vaf_cutoff and \
            (is_matched or row_gnomad_af < self.MAX_UNMATCHED_GNOMAD_AF) and \
+           biotype == "protein_coding" and \
            var_class in sic.MUTATION_TYPES_EXONIC and \
            not any([z in sic.FILTER_FLAGS_EXCLUDE for z in filter_flags]) and \
            not (var_class == "5'Flank" and hugo_symbol != 'TERT'):


### PR DESCRIPTION
Passes snv indel test (1.5.3 version of djerba_test_data)
Passes tmb test (1.5.3 version of djerba_test_data)
No changes to variants or tmb in tests required 