### PR TITLE
Fixed cannot resolve assay issue and updated tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 - GCGI-1382: Fixed TAR disclaimer text (typos, flow)
+- GCGI-1336: Fixed "cannot resolve assay" issue in case overview plugin
 
 ## v1.6.3: 2024-06-26
 

--- a/src/lib/djerba/plugins/case_overview/test/plugin_test.py
+++ b/src/lib/djerba/plugins/case_overview/test/plugin_test.py
@@ -32,7 +32,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_WGTS.ini',
             self.JSON: json_location,
-            self.MD5: '98420eb4576d80fd2944788973c9cb32'
+            self.MD5: '2569e35057de927e2565d8a477fa8fa0'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -42,7 +42,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_TAR.ini',
             self.JSON: json_location,
-            self.MD5: '06d2aa02f67915c9a2f8a9eb1815735e'
+            self.MD5: '7f9c206aa8b10d1f620f52f1fe31d392'
         }
         self.run_basic_test(test_source_dir, params)
 


### PR DESCRIPTION
- The reason it couldn't resolve assay description was it was first taking the non-existent assay (assay = wrapper.get_my_string(self.ASSAY), when there was no assay defined) and then using that to get the assay description. But since the assay was null, it "couldn't resolve assay description".
- The solution to this was to first get it from input params helper (if it exists, else it would take assay from the config), THEN look up assay description/do other things with assay.

Bitbucket PR incoming