### PR TITLE
Fix GCGI-1442 N4 fusion annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- GCGI-1442: Bugfix for processing OncoKB annotation at level N4; update handling of prognostic (P) annotation
+- Includes refactoring of TAR plugins to remove redundant annotation code
+
 ## v1.7.3: 2024-09-16
 - GCGI-1438: Updated genomic landscape plugin (hrd.py) to handle unknown oncotree codes for treatment options
 - GCGI-1262: Remove ABCB1 from TAR reports

--- a/src/lib/djerba/core/html/stylesheet.css
+++ b/src/lib/djerba/core/html/stylesheet.css
@@ -211,11 +211,21 @@ hr.lil-line{
     margin: auto;
   }
 
+.square-dark-text {
+    width: 15px;
+    height: 15px;
+    padding: 5px 8px 5px 5px;
+    color: black;
+    text-align: center;
+    line-height: 15px;
+    margin: auto;
+  }
+
 .oncokb-level1 {background: #33a02c;}
 
 .oncokb-level2 {background: #2078b4;}
 
-.oncokb-level3A {background: #984ea3}
+.oncokb-level3A {background: #984ea3;}
 
 .oncokb-level3B {background: #984ea3;}
 
@@ -230,6 +240,10 @@ hr.lil-line{
 .oncokb-levelN2 {background: #808080;}
 
 .oncokb-levelN3 {background: #AEAEAE;}
+
+.oncokb-levelN4 {background: #C5C5C5;}
+
+.oncokb-levelP {background: #FFA500;}
 
 .tar td[rowspan] {
   vertical-align: top;

--- a/src/lib/djerba/plugins/fusion/fusion_template.html
+++ b/src/lib/djerba/plugins/fusion/fusion_template.html
@@ -8,10 +8,6 @@
 
 ${html_builder().section_cells_begin("<h2>FUSIONS AND STRUCTURAL VARIANTS</h2>","main")}
 
-  <style type="text/css">
-    .oncokb-levelP {background: #000000;}
-  </style>
-
     <p>
       <strong>${results.get(fusion.TOTAL_VARIANTS)}</strong> cancer gene(s) were subject to rearrangement. 
       <strong>${results.get(fusion.CLINICALLY_RELEVANT_VARIANTS)}</strong> fusion(s) were oncogenic according to OncoKB and <strong>${results.get(fusion.NCCN_RELEVANT_VARIANTS)}</strong> rearrangement(s) appeared in the NCCN biomarker compendium.

--- a/src/lib/djerba/plugins/fusion/plugin.py
+++ b/src/lib/djerba/plugins/fusion/plugin.py
@@ -47,8 +47,7 @@ class main(plugin_base):
             [rows, gene_info, treatment_opts] = outputs
             #sort by OncoKB level
             rows = sorted(rows, key=sort_by_actionable_level)
-            max_actionable = oncokb_levels.oncokb_order('P')
-            rows = list(filter(lambda x: oncokb_levels.oncokb_order(x[core_constants.ONCOKB]) <= max_actionable, rows))
+            rows = oncokb_levels.filter_reportable(rows)
             results = {
                 fc.TOTAL_VARIANTS: total_fusion_genes,
                 fc.CLINICALLY_RELEVANT_VARIANTS: fus_reader.get_total_oncokb_fusions(),

--- a/src/lib/djerba/plugins/fusion/test/plugin_test.py
+++ b/src/lib/djerba/plugins/fusion/test/plugin_test.py
@@ -50,7 +50,7 @@ class TestFusion(PluginTester):
         params = {
             self.INI: self.INI_NAME,
             self.JSON: self.JSON_NAME,
-            self.MD5: '140f972adcb7c796128970df64edfba5'
+            self.MD5: '3e5bb853abd4a76dbd45414ea1a9af52'
         }
         self.run_basic_test(input_dir, params, 'fusion', logging.ERROR, work_dir)
 

--- a/src/lib/djerba/plugins/supplement/body/resources/oncokb.definition.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/oncokb.definition.html
@@ -45,6 +45,14 @@
     <td><div class="square oncokb-levelN3">N3</div></td>
     <td>The biomarker is listed as "Predicted Oncogenic" by OncoKB, but is not in an actionable tier</td>
    </tr>
+   <tr>
+    <td><div class="square-dark-text oncokb-levelN4">N4</div></td>
+    <td>The biomarker is listed as "Likely Neutral" or "Inconclusive" by OncoKB</td>
+   </tr>
+   <tr>
+    <td><div class="square oncokb-levelP">P</div></td>
+    <td>The biomarker is listed as "Prognostic" by OncoKB</td>
+   </tr>
   </table>
 
 <p>When provided, results and interpretations are consistent with available knowledge for the given tumour type as defined in <a href="http://oncotree.mskcc.org/">OncoTree</a>. OncoKB tiers are tumour-specific and dependant on OncoTree definitions. </p>

--- a/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
+++ b/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
@@ -34,7 +34,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'TAR.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: '9aa8c4a78bb8eaf9d56ed49a6f0bdeb5'
+            self.MD5: 'ec7793912e579bfdd81fa6cda4dd2e96'
         }
         self.run_basic_test(test_source_dir, params)
    
@@ -54,7 +54,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'f92ca1fbb6bbc2e9cad9d20ecf86dc6a'
+            self.MD5: '2d5453bc1bd3b56f608b2b6ba2c7e3a6'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -74,7 +74,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'eb747b1571dfa16511ef8c9507781eea'
+            self.MD5: 'f15a1bba4120cdd2d96fe5984df1904b'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/extract.py
+++ b/src/lib/djerba/plugins/tar/snv_indel/snv_indel_tools/extract.py
@@ -10,7 +10,7 @@ from djerba.util.environment import directory_finder
 from djerba.util.logger import logger
 from djerba.util.image_to_base64 import converter
 from djerba.util.html import html_builder as hb
-import djerba.util.oncokb.constants as oncokb
+from djerba.util.oncokb.tools import levels as oncokb_levels
 from djerba.util.subprocess_runner import subprocess_runner
 
 class data_builder:
@@ -61,31 +61,16 @@ class data_builder:
                     sic.VAF_PERCENT: int(round(float(input_row[sic.TUMOUR_VAF]), 2)*100),
                     sic.TUMOUR_DEPTH: int(input_row[sic.TUMOUR_DEPTH]),
                     sic.TUMOUR_ALT_COUNT: int(input_row[sic.TUMOUR_ALT_COUNT]),
-                    sic.ONCOKB: self.parse_oncokb_level(input_row)
+                    sic.ONCOKB: oncokb_levels.parse_oncokb_level(input_row)
                 }
-
                 if self.purity >= 0.1 and self.data_CNA_exists:
                     row[sic.COPY_STATE] = mutation_copy_states.get(gene, sic.UNKNOWN)
 
                 rows.append(row)
-        rows = list(filter(self.oncokb_filter, self.sort_variant_rows(rows)))
-        for row in rows: 
-            row[sic.ONCOKB] = self.change_oncokb_level_name(row[sic.ONCOKB])
+        rows = self.sort_variant_rows(rows)
+        rows = oncokb_levels.filter_reportable(rows)
         return rows
  
-    def change_oncokb_level_name(self, level):
-        onc = 'Oncogenic'
-        l_onc = 'Likely Oncogenic'
-        p_onc = 'Predicted Oncogenic'
-        
-        if level == onc:
-            level = 'N1'
-        elif level == l_onc:
-            level = 'N2'
-        elif level == p_onc:
-            level = 'N3'
-        return level
-    
     def cytoband_sort_order(self, cb_input):
         """Cytobands are (usually) of the form [integer][p or q][decimal]; also deal with edge cases"""
         end = (999, 'z', 999999)
@@ -126,42 +111,6 @@ class data_builder:
             msg = "Invalid argument to is_null_string(): '{0}' of type '{1}'".format(value, type(value))
             #self.logger.error(msg)
             raise RuntimeError(msg)
-
-    def oncokb_filter(self, row):
-        """True if level passes filter, ie. if row should be kept"""
-        likely_oncogenic_sort_order = self.oncokb_sort_order(oncokb.LIKELY_ONCOGENIC)
-        return self.oncokb_sort_order(row.get(sic.ONCOKB)) <= likely_oncogenic_sort_order
-  
-    def oncokb_sort_order(self, level):
-        oncokb_levels = [self.reformat_level_string(level) for level in oncokb.ORDERED_LEVELS]
-        order = None
-        i = 0
-        for output_level in oncokb_levels:
-            if level == output_level:
-                order = i
-                break
-            i+=1
-        if order == None:
-            #self.logger.warning(
-            #    "Unknown OncoKB level '{0}'; known levels are {1}".format(level, self.oncokb_levels)
-            #)
-            order = len(oncokb_levels)+1 # unknown levels go last
-        return order
-
-    def parse_oncokb_level(self, row_dict):
-        # find oncokb level string: eg. "Level 1", "Likely Oncogenic", "None"
-        max_level = None
-        for level in oncokb.THERAPY_LEVELS:
-            if not self.is_null_string(row_dict[level]):
-                max_level = level
-                break
-        if max_level:
-            parsed_level = self.reformat_level_string(max_level)
-        elif not self.is_null_string(row_dict[sic.ONCOGENIC]):
-            parsed_level = row_dict[sic.ONCOGENIC]
-        else:
-            parsed_level = sic.NA
-        return parsed_level
 
     def read_cytoband_map(self):
         input_path = self.cytoband_path
@@ -214,5 +163,5 @@ class data_builder:
         #self.logger.debug("Sorting rows by cytoband")
         rows = sorted(rows, key=lambda row: self.cytoband_sort_order(row[sic.CHROMOSOME]))
         #self.logger.debug("Sorting rows by oncokb level")
-        rows = sorted(rows, key=lambda row: self.oncokb_sort_order(row[sic.ONCOKB]))
+        rows = sorted(rows, key=lambda row: oncokb_levels.oncokb_order(row[sic.ONCOKB]))
         return rows

--- a/src/lib/djerba/plugins/wgts/common/cnv/tools.py
+++ b/src/lib/djerba/plugins/wgts/common/cnv/tools.py
@@ -136,7 +136,8 @@ class cnv_processor(logger):
                 rows.append(row_output)
         unfiltered_cnv_total = len(rows)
         self.logger.debug("Sorting and filtering CNV rows")
-        rows = list(filter(oncokb_levels.oncokb_filter, wgts_toolkit.sort_variant_rows(rows)))
+        rows = wgts_toolkit.sort_variant_rows(rows)
+        rows = oncokb_levels.filter_reportable(rows)
         results = {
             cnv.PERCENT_GENOME_ALTERED: self.calculate_percent_genome_altered(),
             cnv.TOTAL_VARIANTS: unfiltered_cnv_total,

--- a/src/lib/djerba/plugins/wgts/snv_indel/tools.py
+++ b/src/lib/djerba/plugins/wgts/snv_indel/tools.py
@@ -249,7 +249,8 @@ class snv_indel_processor(logger):
                     wgts_tools.ONCOKB: oncokb_levels.parse_oncokb_level(row_input)
                 }
                 rows.append(row_output)
-        rows = list(filter(oncokb_levels.oncokb_filter, wgts_toolkit.sort_variant_rows(rows)))
+        rows = wgts_toolkit.sort_variant_rows(rows)
+        rows = oncokb_levels.filter_reportable(rows)
         somatic_total, coding_seq_total = self.get_mutation_totals()
         results = {
             sic.SOMATIC_MUTATIONS: somatic_total,

--- a/src/lib/djerba/util/html.py
+++ b/src/lib/djerba/util/html.py
@@ -8,6 +8,7 @@ from markdown import markdown
 
 class html_builder:
 
+    ONCOKB_URL_PREFIX = 'https://www.oncokb.org/gene' # TODO move to util.oncokb.tools?
     TABLE_START = '<table border=1>'
     TABLE_END = '</table>'
     TR_START = '<tr style="text-align:left;">'
@@ -15,12 +16,12 @@ class html_builder:
 
     @staticmethod
     def build_alteration_url(gene, alteration, cancer_code):
-        base = 'https://www.oncokb.org/gene'
-        return '/'.join([base, gene, alteration, cancer_code])
+        return '/'.join([html_builder.ONCOKB_URL_PREFIX, gene, alteration, cancer_code])
 
     @staticmethod
     def build_fusion_url(genes, oncotree_code):
-        url = 'https://www.oncokb.org/gene/{0}/Fusion/{1}'.format(
+        url = '{0}/{1}/Fusion/{2}'.format(
+            html_builder.ONCOKB_URL_PREFIX,
             '-'.join(genes),
             oncotree_code
         )
@@ -28,7 +29,8 @@ class html_builder:
     
     @staticmethod
     def build_onefusion_url(gene, oncotree_code):
-        url = 'https://www.oncokb.org/gene/{0}/Fusion/{1}'.format(
+        url = '{0}/{1}/Fusion/{2}'.format(
+            html_builder.ONCOKB_URL_PREFIX,
             gene,
             oncotree_code
         )
@@ -36,7 +38,7 @@ class html_builder:
 
     @staticmethod
     def build_gene_url(gene):
-        return 'https://www.oncokb.org/gene/'+gene
+        return html_builder.ONCOKB_URL_PREFIX+'/'+gene
 
     @staticmethod
     def expression_display(expr):

--- a/src/lib/djerba/util/html.py
+++ b/src/lib/djerba/util/html.py
@@ -5,6 +5,7 @@
 import re
 from string import Template
 from markdown import markdown
+from djerba.util.oncokb.tools import levels as oncokb_levels
 
 class html_builder:
 
@@ -119,15 +120,7 @@ class html_builder:
         # make a table cell with an OncoKB level symbol
         # permitted levels must have a format defined in style.css
         level = re.sub('Level ', '', level) # strip off 'Level ' prefix, if any
-        permitted_levels = ['1', '2', '3A', '3B', '4', 'R1', 'R2', 'N1', 'N2', 'N3','P']
-        if not level in permitted_levels:
-            msg = "Input '{0}' is not a permitted OncoKB level".format(level)
-            raise RuntimeError(msg)
-        if level in ['N1', 'N2', 'N3','P']:
-            shape = 'square'
-        else:
-            shape = 'circle'
-        div = '<div class="{0} oncokb-level{1}">{2}</div>'.format(shape, level, level)
+        div = oncokb_levels.oncokb_level_to_html(level)
         return html_builder.td(div)
 
     @staticmethod

--- a/src/lib/djerba/util/oncokb/constants.py
+++ b/src/lib/djerba/util/oncokb/constants.py
@@ -26,9 +26,8 @@ LIKELY_ONCOGENIC = 'Likely Oncogenic'
 INCONCLUSIVE = 'Inconclusive'
 UNKNOWN = 'Unknown'
 
-FDA_APPROVED_LEVELS = [LEVEL_1, LEVEL_2, LEVEL_R1]
-INVESTIGATIONAL_LEVELS = [LEVEL_3A, LEVEL_3B, LEVEL_4, LEVEL_R2]
-THERAPY_LEVELS = [
+# used for parsing OncoKB-annotated MAF files
+ANNOTATION_THERAPY_LEVELS = [
     LEVEL_1,
     LEVEL_2,
     LEVEL_3A,
@@ -36,19 +35,6 @@ THERAPY_LEVELS = [
     LEVEL_4,
     LEVEL_R1,
     LEVEL_R2,
-]
-ORDERED_LEVELS = [
-    LEVEL_1,
-    LEVEL_2,
-    LEVEL_3A,
-    LEVEL_3B,
-    LEVEL_4,
-    LEVEL_R1,
-    LEVEL_R2,
-    ONCOGENIC,
-    LIKELY_ONCOGENIC,
-    INCONCLUSIVE,
-    UNKNOWN
 ]
 
 ### INI config keys ###

--- a/src/lib/djerba/util/oncokb/tools.py
+++ b/src/lib/djerba/util/oncokb/tools.py
@@ -12,7 +12,6 @@ from djerba.util.logger import logger
 class levels:
 
     ACTIONABLE_LEVELS = ['1', '2', '3A', '3B', '4', 'R1', 'R2', 'P']
-    REPORTABLE_LEVELS = ['1', '2', '3A', '3B', '4', 'R1', 'R2', 'N1', 'N2', 'P']
     ALL_LEVELS = ['1', '2', '3A', '3B', '4', 'R1', 'R2', 'N1', 'N2', 'N3', 'N4', 'P', 'Unknown']
 
     @staticmethod
@@ -21,7 +20,7 @@ class levels:
             return value in ['', 'NA']
         else:
             msg = "Invalid argument to is_null_string(): '{0}' of type '{1}'".format(value, type(value))
-            raise RuntimeError(msg)
+            raise ValueError(msg)
 
     @staticmethod
     def oncokb_filter(row):
@@ -37,31 +36,16 @@ class levels:
 
     @staticmethod
     def oncokb_level_to_html(level):
-        if level == "1" or level == 1:
-            html = '<div class="circle oncokb-level1">1</div>'
-        elif level == "2" or level == 2:
-            html = '<div class="circle oncokb-level2">2</div>'
-        elif level == "3A":
-            html = '<div class="circle oncokb-level3A">3A</div>'
-        elif level == "3B":
-            html = '<div class="circle oncokb-level3B">3B</div>'
-        elif level == "4":
-            html = '<div class="circle oncokb-level4">4</div>'
-        elif level == "R1":
-            html = '<div class="circle oncokb-levelR1">R1</div>'
-        elif level == "R2":
-            html = '<div class="circle oncokb-levelR2">R2</div>'
-        elif level == "N1":
-            html = '<div class="square oncokb-levelN1">N1</div>'
-        elif level == "N2":
-            html = '<div class="square oncokb-levelN2">N2</div>'
-        elif level == "N3":
-            html = '<div class="square oncokb-levelN3">N3</div>'
-        elif level == "P":
-            html = '<div class="square oncokb-levelP">P</div>'
+        if level in ['1', '2', '3A', '3B', '4', 'R1', 'R2']:
+            shape = 'circle'
+        elif level in ['N1', 'N2','P']:
+            shape = 'square'
+        elif level in ['N3', 'N4']:
+            shape = 'square-dark-text'
         else:
-            raise RuntimeError("Unknown OncoKB level: '{0}'".format(level))
-        return html
+            raise UnrecognizedOncokbLevelError("Unrecognized OncoKB level: {0}".format(level))
+        div = '<div class="{0} oncokb-level{1}">{1}</div>'.format(shape, level)
+        return div
 
     @staticmethod
     def oncokb_order(level):
@@ -73,7 +57,7 @@ class levels:
                 order = i
                 break
         if order == None:
-            raise RuntimeError("Unknown OncoKB level: {0}".format(level))
+            raise UnrecognizedOncokbLevelError("Unrecognized OncoKB level: {0}".format(level))
         return order
 
     @staticmethod
@@ -165,3 +149,6 @@ class gene_summary_reader(logger):
 
     def get(self, gene):
         return self.summaries.get(gene, self.DEFAULT)
+
+class UnrecognizedOncokbLevelError(Exception):
+    pass

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -37,7 +37,7 @@ class TestCore(TestBase):
     SIMPLE_REPORT_JSON = 'simple_report_expected.json'
     SIMPLE_REPORT_UPDATE_JSON = 'simple_report_for_update.json'
     SIMPLE_CONFIG_MD5 = '04b749b3ec489ed9c06c1a06eb2dc886'
-    SIMPLE_REPORT_MD5 = 'e4b491b28457b5b12a320ea11c6c47e5'
+    SIMPLE_REPORT_MD5 = 'ab049488c58758e26b0ad1c480c28c99'
 
     class mock_args:
         """Use instead of argparse to store params for testing"""

--- a/src/test/util/mini/test_mini.py
+++ b/src/test/util/mini/test_mini.py
@@ -16,8 +16,8 @@ class TestMiniBase(TestBase):
 
     JSON_NAME = 'simple_report_for_update.json'
     JSON_NO_SUMMARY = 'simple_report_no_summary.json'
-    REPORT_MD5 = '4e40169d5ba33d4509681a7ee8831893'
-    REPORT_NO_SUMMARY_MD5 = '8c8b57ed19c35ee6dd1782656691c867'
+    REPORT_MD5 = 'f56a78445a3a64cc077b6ca7b93ddf34'
+    REPORT_NO_SUMMARY_MD5 = '6766824e807109434298d6dce4360ca9'
 
     def assert_setup(self, ini_path, summary_path=None):
         self.assertTrue(os.path.exists(ini_path))
@@ -280,7 +280,7 @@ class TestScript(TestMiniBase):
         cmd.append('--force')
         result = subprocess_runner().run(cmd)
         self.assertEqual(result.returncode, 0)
-        self.assert_report('860a0b0ac19aa1daed9650a7f8b612a8')
+        self.assert_report('ecd454e235848c7c58118899edc06fa3')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fixes bug in which N4 annotation could not be rendered
- Update and fix OncoKB filtering, N3 & N4 annotations are removed from output
- Consolidate OncoKB processing in util.oncokb.tools where possible
- Remove redundant OncoKB processing from TAR and other plugins
- Update supplementary body with N4 and P definitions

Screenshot of new definitions:
![actionability](https://github.com/user-attachments/assets/115291e4-9225-48c3-ac5e-7ca2bc0d2d96)
