### PR TITLE
GCGI-1534 commenting out plugin tester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - GCGI-1527: Deprecating tube_ID and switching to group_ID
 - GCGI-1530: Update test_env.sh for new data directory
 - GCGI-1474: Additional Debug logs for tissue type filtering conditions
+- GCGI-1534: Fix issues with plugin tester; output test reports to working directory
 
 ## v1.8.1: 2025-03-04
 - GCGI-1455: New `tar.status` plugin to add a display box for ctDNA status

--- a/src/lib/djerba/helpers/provenance_helper/test/helper_test.py
+++ b/src/lib/djerba/helpers/provenance_helper/test/helper_test.py
@@ -20,7 +20,7 @@ class TestProvenanceHelper(TestBase):
     HELPER_NAME = 'provenance_helper'
     SUBSET_LENGTH = 240
     SAMPLE_INFO_MD5 = 'd8ca7199822984ad4ec7f0fee5cbb316'
-    PATH_INFO_MD5 = 'fbb9daa1fd1f6d0ef1eaa8e2f587d021'
+    PATH_INFO_MD5 = '89fc04b99bedca1fd8d34d3f738786fa'
     
     def test(self):
         self.data_dir_root = directory_finder().get_test_dir()

--- a/src/lib/djerba/plugins/plugin_tester.py
+++ b/src/lib/djerba/plugins/plugin_tester.py
@@ -64,8 +64,7 @@ class PluginTester(TestBase):
         # report_dir contains report files in case needed for troubleshooting
         # if work_dir is not None, report_dir will persist for later viewing
         report_dir = os.path.join(work_dir, 'test_reports')
-        if not os.path.isdir(report_dir):
-            os.mkdir(report_dir)
+        os.makedirs(report_dir, exist_ok=True)
         ini_path = os.path.join(test_source_dir, params[self.INI])
         expected_json_path = os.path.join(test_source_dir, params[self.JSON])
         expected_md5 = params[self.MD5]

--- a/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
+++ b/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
@@ -39,7 +39,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'PWGS.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'f808bc34cb7f88c48c4451d96f60ef9b'
+            self.MD5: '9f94cbdeeca2719e91516bf64c22d116'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -48,7 +48,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'TAR.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'd5cf18b4ce0117669344d6f9486d093a'
+            self.MD5: '9c6b36c43e2282f4c4e522bdd4e57be9'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
    
@@ -57,7 +57,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'TAR.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'f596822789e57599577d82d928401566'
+            self.MD5: 'a05fcea63a32f2b64247541e1ab95830'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -66,7 +66,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.supp.ini',
             self.JSON: json_location,
-            self.MD5: '604b876c3d0e8666c68a5255bf5b032d'
+            self.MD5: 'e32f29f0fecfa4d203ea882e78f82778'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -75,7 +75,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '00aba2543b096835c79b18272b30da09'
+            self.MD5: '1b94975ccfa4921187a9d6c3f6b7680a'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -84,7 +84,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'ae4e88e8bd275963bff07083c0c86479'
+            self.MD5: 'c598dbde092c2d81e3acadae4934a524'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -93,7 +93,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.supp.ini',
             self.JSON: json_location,
-            self.MD5: '687b8775387ed1682c9c3abcbda39b05'
+            self.MD5: 'e7ef1a1fb4b9a5cbfc5bc5e426f9dc8d'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -102,7 +102,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: '7eb82799614be10e683e55813e9e45f9'
+            self.MD5: '102f962c48c39a4b61cf45f3491fe410'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -111,7 +111,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '72cc97d67cd7eb4445ed2cabab21b8ad'
+            self.MD5: 'cbf90e980964d8aaa6a17fe15b8e2528'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
     

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -634,13 +634,13 @@ class TestMainScript(TestCore):
         ]
         result = subprocess_runner().run(cmd)
         self.assertEqual(result.returncode, 0)
-        self.assertEqual(self.getMD5(ini_path), 'a211144356b5ec200e1c31ecd3128b45')
+        self.assertEqual(self.getMD5(ini_path), 'f7ebb517b700779268e9dcd5f6089f67')
         os.remove(ini_path)
         prepop_path = os.path.join(self.test_source_dir, 'prepop.ini')
         cmd.extend(['--pre-populate', prepop_path])
         result = subprocess_runner().run(cmd)
         self.assertEqual(result.returncode, 0)
-        self.assertEqual(self.getMD5(ini_path), '2387e66d783b1deb0fe5361e7770ec7a')
+        self.assertEqual(self.getMD5(ini_path), 'e13e0e9dcfe863476bfc6487499382e3')
 
     def test_update_cli_with_ini(self):
         mode = 'update'


### PR DESCRIPTION
- Fix mistaken commenting-out of line in plugin tester
- Output test reports to the working directory, in case needed for troubleshooting
- Some test failures for apparently unrelated issues: expression helper and genomic landscale (missing TCGA code), tar SWGS (missing test data), see attached file
[test_failures_20250317.txt](https://github.com/user-attachments/files/19298747/test_failures_20250317.txt)
