### PR TITLE
GCGI-1539 couchdb security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 - GCGI-1109: Update "Patient Genetic Sex" to "Patient sex assigned at birth"
 - GCGI-1544: Handle missing or empty HLA data
+- GCGI-1539: Environment variable for CouchDB credentials
 - GCGI-1546: Fix installation of INI templates for benchmark script
 
 ## v1.8.3: 2025-03-27

--- a/src/lib/djerba/core/configure.py
+++ b/src/lib/djerba/core/configure.py
@@ -388,11 +388,6 @@ class core_configurer(configurable):
         self.add_ini_discovered(cc.AUTHOR)
         self.add_ini_discovered(cc.REPORT_ID)
         self.set_ini_default(cc.REPORT_VERSION, 1)
-        self.set_ini_default(cc.ARCHIVE_NAME, "djerba")
-        self.set_ini_default(
-            cc.ARCHIVE_URL,
-            "http://${username}:${password}@${address}:${port}"
-        )
         self.set_ini_default(cc.INPUT_PARAMS_FILE, cc.DEFAULT_INPUT_PARAMS)
         self.set_ini_default(cc.DOCUMENT_CONFIG, cc.DEFAULT_DOCUMENT_CONFIG)
 

--- a/src/lib/djerba/core/constants.py
+++ b/src/lib/djerba/core/constants.py
@@ -49,8 +49,6 @@ WORKSPACE = 'workspace'
 # keys for core config/extract
 REPORT_ID = 'report_id'
 REPORT_VERSION = 'report_version'
-ARCHIVE_NAME = 'archive_name'
-ARCHIVE_URL = 'archive_url'
 AUTHOR = 'author'
 EXTRACT_TIME = 'extract_time'
 INPUT_PARAMS_FILE = 'input_params'
@@ -82,12 +80,15 @@ DEFAULT_AUTHOR = "CGI Author"
 DEFAULT_DOCUMENT_CONFIG = "document_config.json"
 
 # archive config
-ARCHIVE_CONFIG = 'archive_config.ini'
 ARCHIVE_HEADER = 'archive'
 USERNAME = 'username'
 PASSWORD = 'password'
 ADDRESS = 'address'
 PORT = 'port'
+DATABASE_NAME = 'database_name'
+# environment variable for database config
+ARCHIVE_CONFIG_VAR = 'DJERBA_ARCHIVE_CONFIG'
+
 
 # keywords for document rendering
 BODY = 'body'

--- a/src/lib/djerba/core/database.py
+++ b/src/lib/djerba/core/database.py
@@ -95,6 +95,7 @@ class database(logger):
                     self.logger.debug('Attempting PUT for {0}'.format(report_id))
                     result = requests.put(url=url_with_id, headers=headers, json=upload_doc)
             status = result.status_code
+            self.logger.debug("HTTP result: {0}, {1}".format(status, result.reason))
             if status == 201:
                 uploaded = True
             elif status == 409:


### PR DESCRIPTION
- Get the INI file with database credentials from an environment variable `DJERBA_ARCHIVE_CONFIG` instead of the main Djerba config
- Put the database name in the INI instead of configuring it separately
- Next Modulator PR to include the new environment variable