### PR TITLE
Gcgi 1607 limit hrd reporting above 115 x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 - GCGI-1599: Update NCCN guidelines versions for ovarian (2023 to 2025) and PCM (2023 to 2026)
 - GCGI-1598: Updated Illumina version to v1.3, pipeline version to 6.0, WGTS assay versions to 6.0, PWGS assay version to 3.0, and added warning to inform user which instrument the sample was sequenced on
+- GCGI-1607: Limited HRD reporting above 115X corresponding to Illumina version update to v1.3
 
 ## v1.10.1: 2025-06-27
 - GCGI-1597: Fixes for benchmarking script. Omit copying ichorCNA file if not available. Update or remove outdated INI parameters.

--- a/src/lib/djerba/plugins/genomic_landscape/constants.py
+++ b/src/lib/djerba/plugins/genomic_landscape/constants.py
@@ -16,6 +16,7 @@ UNKNOWN_SAMPLE_TYPE = 'Unknown sample type'
 # biomarker reportability
 CAN_REPORT_HRD = 'can_report_hrd'
 CAN_REPORT_MSI = 'can_report_msi'
+CANT_REPORT_HRD_REASON = 'cant_report_hrd_reason'
 
 # For MSI file
 MSI_RESULTS_SUFFIX = '.recalibrated.msi.booted'

--- a/src/lib/djerba/plugins/genomic_landscape/genomic_landscape_template.html
+++ b/src/lib/djerba/plugins/genomic_landscape/genomic_landscape_template.html
@@ -31,7 +31,7 @@ ${html_builder().section_cells_begin("<h2>Genomic Landscape</h2>","main")}
                   <th style="width:80%">Score & Confidence</th>
             </thead>
             <tbody>
-                  % for row in gl_html_builder().biomarker_table_rows(results.get(constants.BIOMARKERS), results.get(constants.CAN_REPORT_HRD), results.get(constants.CAN_REPORT_MSI)):
+                  % for row in gl_html_builder().biomarker_table_rows(results.get(constants.BIOMARKERS), results.get(constants.CAN_REPORT_HRD), results.get(constants.CANT_REPORT_HRD_REASON), results.get(constants.CAN_REPORT_MSI)):
                   ${row}
                   % endfor 
             </tbody>

--- a/src/lib/djerba/plugins/genomic_landscape/plugin.py
+++ b/src/lib/djerba/plugins/genomic_landscape/plugin.py
@@ -6,6 +6,7 @@ import os
 import re
 
 import djerba.core.constants as core_constants
+import djerba.plugins.sample.constants as sample_constants
 import djerba.plugins.genomic_landscape.constants as glc
 import djerba.plugins.wgts.cnv_purple.constants as purple_constants
 import djerba.util.oncokb.constants as oncokb_constants
@@ -20,7 +21,7 @@ from djerba.util.environment import directory_finder
 from djerba.util.oncokb.annotator import annotator_factory
 from djerba.util.oncokb.tools import levels as oncokb_levels
 from djerba.util.render_mako import mako_renderer
-
+from djerba.core.workspace import workspace
 
 class main(plugin_base):
     PLUGIN_VERSION = '2.0.0'
@@ -60,7 +61,7 @@ class main(plugin_base):
         self.set_ini_default(oncokb_constants.UPDATE_CACHE, False)
 
         # Default parameters for priorities
-        self.set_ini_default('configure_priority', 100)
+        self.set_ini_default('configure_priority', 500)
         self.set_ini_default('extract_priority', 1000)
         self.set_ini_default('render_priority', 500)
 
@@ -103,13 +104,20 @@ class main(plugin_base):
         results = tmb_processor(self.log_level, self.log_path).run(
             work_dir, plugin_data_dir, r_script_dir, tcga_code, biomarkers_path, tumour_id
         )
+        
+        # Get coverage for reporting HRD
+        coverage = float(self.workspace.read_maybe_json(sample_constants.QC_SAMPLE_INFO)[sample_constants.COVERAGE_MEAN])
+
         # evaluate HRD and MSI reportability
-        hrd_ok, msi_ok = self.evaluate_reportability(
+        hrd_ok, msi_ok, cant_report_hrd_reason = self.evaluate_reportability(
             wrapper.get_my_float(glc.PURITY_INPUT),
+            coverage,
             wrapper.get_my_string(glc.SAMPLE_TYPE)
         )
         results[glc.CAN_REPORT_HRD] = hrd_ok
         results[glc.CAN_REPORT_MSI] = msi_ok
+        results[glc.CANT_REPORT_HRD_REASON] = cant_report_hrd_reason
+
         # evaluate biomarkers
         ctdna_file = wrapper.get_my_string(glc.CTDNA_FILE)
         ctdna_proc = ctdna_processor(self.log_level, self.log_path)
@@ -164,7 +172,7 @@ class main(plugin_base):
         annotator.annotate_biomarkers_maf(input_path, output_path)
         return output_path
 
-    def evaluate_reportability(self, purity, sample_type):
+    def evaluate_reportability(self, purity, coverage, sample_type):
         # evaluate reportability for HRD and MSI metrics
         self.logger.debug('Evaluating reportability for purity and sample type')
         sample_is_ffpe = False
@@ -175,17 +183,22 @@ class main(plugin_base):
             self.logger.warning("Unknown sample type in config; assuming non-FFPE sample")
         else:
             self.logger.debug('Non-FFPE sample detected')
-        if purity >= 0.5 or (purity >= 0.3 and not sample_is_ffpe):
+        if (purity >= 0.5 or (purity >= 0.3 and not sample_is_ffpe)) and coverage <= 115:
             hrd_ok = True
+            cant_report_hrd_reason = None
+        elif coverage > 115:
+            hrd_ok = False
+            cant_report_hrd_reason = "coverage"
         else:
             hrd_ok = False
+            cant_report_hrd_reason = "purity"
         if purity >= 0.5:
             msi_ok = True
         else:
             msi_ok = False
         self.logger.debug("HRD reportable: {0}".format(hrd_ok))
         self.logger.debug("MSI reportable: {0}".format(msi_ok))
-        return (hrd_ok, msi_ok)
+        return (hrd_ok, msi_ok, cant_report_hrd_reason)
 
     def get_oncokb_merge_inputs(self, annotated_maf_path, msi_ok):
         """

--- a/src/lib/djerba/plugins/genomic_landscape/plugin.py
+++ b/src/lib/djerba/plugins/genomic_landscape/plugin.py
@@ -185,7 +185,7 @@ class main(plugin_base):
             self.logger.debug('Non-FFPE sample detected')
         if (purity >= 0.5 or (purity >= 0.3 and not sample_is_ffpe)) and coverage <= 115:
             hrd_ok = True
-            cant_report_hrd_reason = None
+            cant_report_hrd_reason = False
         elif coverage > 115:
             hrd_ok = False
             cant_report_hrd_reason = "coverage"

--- a/src/lib/djerba/plugins/genomic_landscape/render.py
+++ b/src/lib/djerba/plugins/genomic_landscape/render.py
@@ -11,15 +11,25 @@ class html_builder:
         cell = template.format(biomarker,plot)
         return(cell)
 
-    def biomarker_table_rows(self, biomarkers, can_report_hrd, can_report_msi):
+    def biomarker_table_rows(self, biomarkers, can_report_hrd, cant_report_hrd_reason, can_report_msi):
         rows = []
         for marker, info in biomarkers.items():
-            if marker == "HRD" and not can_report_hrd:
-                cells = [
-                    hb.td(info[constants.ALT]),
-                    hb.td("NA"),
-                    hb.td("Cancer cell content below threshold to evaluate HRD; must be &#8805;50&#37; for FFPE samples, &#8805;30&#37; otherwise")
-                ]
+            if marker == "HRD" and not can_report_hrd and cant_report_hrd_reason:
+                if cant_report_hrd_reason == "purity":
+                    cells = [
+                        hb.td(info[constants.ALT]),
+                        hb.td("NA"),
+                        hb.td("Cancer cell content below threshold to evaluate HRD; must be &#8805;50&#37; for FFPE samples, &#8805;30&#37; otherwise")
+                    ]
+                elif cant_report_hrd_reason == "coverage":
+                    cells = [
+                        hb.td(info[constants.ALT]),
+                        hb.td("NA"),
+                        hb.td("Coverage above threshold to evaluate HRD; must be &#8804;115X")
+                    ]
+                else:
+                    msg = "Cannot report HRD reason: {0}. The only valid reasons for HRD to not be reported are purity and coverage".format(cant_report_hrd_reason)
+                    self.logger.error(msg)
             elif marker == "MSI" and not can_report_msi:
                 cells = [
                     hb.td(info[constants.ALT]),

--- a/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
+++ b/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
@@ -31,6 +31,8 @@ class TestGenomicLandscapePlugin(PluginTester):
         self.data_mut_ex = os.path.join(self.plugin_test_dir, "data_mutations_extended.txt")
         self.data_seg = os.path.join(self.plugin_test_dir, "data.seg")
         self.sample_info = os.path.join(self.plugin_test_dir, "sample_info.json")
+        self.sample_qc = os.path.join(self.plugin_test_dir, "sample_qcs.json")
+        self.sample_qc_high_cov = os.path.join(self.plugin_test_dir, "sample_qcs_high_cov.json")
 
     def testNCCNAnnotation(self):
         # contains oncotree file
@@ -50,6 +52,7 @@ class TestGenomicLandscapePlugin(PluginTester):
         shutil.copy(self.data_mut_ex, self.tmp_dir)
         shutil.copy(self.data_seg, self.tmp_dir)
         shutil.copy(self.sample_info, self.tmp_dir)
+        shutil.copy(self.sample_qc, self.tmp_dir)
 
         with open(os.path.join(test_source_dir, self.INI_NAME)) as in_file:
             template_str = in_file.read()
@@ -66,6 +69,32 @@ class TestGenomicLandscapePlugin(PluginTester):
             self.MD5: '690242139aab0153348e7a4634d2f17c'
         }
         self.run_basic_test(input_dir, params)
+
+    def testGenomicLandscapeLowTmbStableMsiHighCoverage(self):
+        test_source_dir = os.path.realpath(os.path.dirname(__file__))
+
+        # Copy files into the temporary directory
+        shutil.copy(self.data_mut_ex, self.tmp_dir)
+        shutil.copy(self.data_seg, self.tmp_dir)
+        shutil.copy(self.sample_info, self.tmp_dir)
+        shutil.copy(self.sample_qc_high_cov, f"{self.tmp_dir}/sample_qcs.json")
+
+        with open(os.path.join(test_source_dir, self.INI_NAME)) as in_file:
+            template_str = in_file.read()
+        template = string.Template(template_str)
+        ini_str = template.substitute({'DJERBA_TEST_DIR': self.sup_dir})
+        input_dir = os.path.join(self.get_tmp_dir(), 'input')
+        os.mkdir(input_dir)
+        with open(os.path.join(input_dir, self.INI_NAME), 'w') as ini_file:
+            ini_file.write(ini_str)
+        json_location = os.path.join(self.plugin_test_dir, "report_json", "genomic_landscape_high_cov.json")
+        params = {
+            self.INI: self.INI_NAME,
+            self.JSON: json_location,
+            self.MD5: '2851dc05b9e92514e1eff82f8c992663'
+        }
+        self.run_basic_test(input_dir, params)
+
 
     def redact_json_data(self, data):
         """replaces empty method from testing.tools"""

--- a/src/lib/djerba/plugins/sample/constants.py
+++ b/src/lib/djerba/plugins/sample/constants.py
@@ -10,6 +10,7 @@ COVERAGE = "mean_coverage"
 PURITY = "purity"
 PLOIDY = "ploidy"
 DONOR = "donor"
+QC_SAMPLE_INFO = "sample_qcs.json"
 
 # Parameters for rendering
 ONCOTREE_CODE = 'OncoTree code'

--- a/src/lib/djerba/plugins/sample/plugin.py
+++ b/src/lib/djerba/plugins/sample/plugin.py
@@ -25,7 +25,6 @@ except ImportError as err:
 class main(plugin_base):
 
     PLUGIN_VERSION = '1.0.0'
-    PRIORITY = 500
     QCETL_CACHE = "/scratch2/groups/gsi/production/qcetl_v1"
     
     def specify_params(self):
@@ -42,7 +41,12 @@ class main(plugin_base):
         for key in discovered:
             self.add_ini_discovered(key)
         self.set_ini_default(core_constants.ATTRIBUTES, 'clinical')
-        self.set_priority_defaults(self.PRIORITY)
+        
+        # Default parameters for priorities
+        self.set_ini_default('configure_priority', 100)
+        self.set_ini_default('extract_priority', 500)
+        self.set_ini_default('render_priority', 500)
+
 
     def configure(self, config):
         config = self.apply_defaults(config)
@@ -103,6 +107,7 @@ class main(plugin_base):
                 constants.COVERAGE_MEAN: config[self.identifier][constants.COVERAGE]    
         }
         data['results'] = results
+        self.workspace.write_json(constants.QC_SAMPLE_INFO, results)
         return data
 
     def render(self, data):

--- a/src/lib/djerba/plugins/supplement/body/resources/WGS.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/WGS.disclaimer.html
@@ -2,7 +2,7 @@
 Based on a minimum tumour purity of 30%, the sensitivity for SNVs and in/dels is 96% and 89%, respectively. 
 The sensitivity for CNVs and RNA fusions is 100% and 32%, respectively. 
 The limit of detection is 10% VAF for SNVs and 20% for in/dels. The limit of detection for MSI is cellularity &ge;50%.
-For HRD, the sensitivity is 83% and the specificity is 90%. The lower limit of detection is &ge;50% cellularity in FFPE samples and &ge;30% cellularity in fresh frozen samples.
+For HRD, the sensitivity is 83% and the specificity is 90%. The lower limit of detection is &ge;50% cellularity in FFPE samples and &ge;30% cellularity in fresh frozen samples. The upper limit of detection is 115X mean coverage. 
 For LOH, the sensitivity and specificity are both 100%. LOH is currently reported for autosomes; LOH on the X chromosome is not reported. Germline HLA allele calling sensitivity is above 95%.
 Although whole genome sequencing encompasses all genes in a specimen, this report is restricted to cancer genes defined by OncoKB as of the date the report is issued.
 The test was validated for somatic variant detection and it does not detect germline variants. Therefore, we cannot rule out the possibility that a germline variant exists that was not detectable using these methodologies. This test does not replace the need for germline testing in the context of hereditary cancer suspicion.

--- a/src/lib/djerba/plugins/supplement/body/resources/WGS40X.disclaimer.html
+++ b/src/lib/djerba/plugins/supplement/body/resources/WGS40X.disclaimer.html
@@ -2,7 +2,7 @@
 Based on a minimum tumour purity of 65%, the sensitivity for SNVs and in/dels is 96% and 77.7%, respectively. 
 The sensitivity for CNVs and RNA fusions is 100% and 32%, respectively. 
 The limit of detection is 10% VAF for SNVs and 20% for in/dels. The limit of detection for MSI is cellularity &ge;50%.
-For HRD, the sensitivity is 83% and the specificity is 90%. The lower limit of detection is &ge;50% cellularity in FFPE samples and &ge;30% cellularity in fresh frozen samples.
+For HRD, the sensitivity is 83% and the specificity is 90%. The lower limit of detection is &ge;50% cellularity in FFPE samples and &ge;30% cellularity in fresh frozen samples. The upper limit of detection is 115X mean coverage. 
 For LOH, the sensitivity and specificity are both 100%. LOH is currently reported for autosomes; LOH on the X chromosome is not reported. Germline HLA allele calling sensitivity is above 95%.
 Although whole genome sequencing encompasses all genes in a specimen, this report is restricted to cancer genes defined by OncoKB as of the date the report is issued.
 The test was validated for somatic variant detection and it does not detect germline variants. Therefore, we cannot rule out the possibility that a germline variant exists that was not detectable using these methodologies. This test does not replace the need for germline testing in the context of hereditary cancer suspicion.

--- a/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
+++ b/src/lib/djerba/plugins/supplement/body/test/plugin_test.py
@@ -66,7 +66,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.supp.ini',
             self.JSON: json_location,
-            self.MD5: '25de723b077017ff5c6b859253890695'
+            self.MD5: '6cf192bf13bcfa7d13ae56db94217950'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -75,7 +75,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '1e670c1638a9b0a5f55af3b3c4f81566'
+            self.MD5: '141b67c2bf56510c7beda9d5ead50373'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -84,7 +84,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: '5473cd1d60e40e638a8b9028d7de4cda'
+            self.MD5: 'f918b18e45eea962b744db5f42d5986c'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -93,7 +93,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.supp.ini',
             self.JSON: json_location,
-            self.MD5: 'f378a169abe1335deb2d897e57249f83'
+            self.MD5: '7c02df5e8da858b43a3e09e7ae1ed2e5'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -102,7 +102,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.RESEARCH.supp.ini',
             self.JSON: json_location,
-            self.MD5: '84f3a9c77ca6acdd5823d8a4f6a977ee'
+            self.MD5: '46919ec8dc026e5bd9cfd22d52e70ddb'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
 
@@ -111,7 +111,7 @@ class TestSupplementaryPluginBody(PluginTester):
         params = {
             self.INI: 'WGTS40X.FAIL.supp.ini',
             self.JSON: json_location,
-            self.MD5: '16a0d82e015fd050852862046dd5606a'
+            self.MD5: 'c5e0d194d754c9145f6ff79f8ac315a5'
         }
         self.run_basic_test(self.test_source_dir, params, work_dir=self.work_dir)
     


### PR DESCRIPTION
The following plugins were tweaked in this PR:
- genomic landscape plugin (limiting HRD to report only when <= 115X. If both low purity and <=115X, will display the 115X reason).
- sample plugin (to write its results into sample_qcs.json to the workplace, so that the genomic landscape plugin will have access to mean coverage. Had to change the configure/extract priorities for this)
- supplement plugin (to add upper limit of detection 115X to HRD part of disclaimer)
All three plugin tests pass