### PR TITLE
snv_indel : ensure chromosome column is type str

### DIFF
--- a/src/lib/djerba/plugins/wgts/snv_indel/tools.py
+++ b/src/lib/djerba/plugins/wgts/snv_indel/tools.py
@@ -146,7 +146,7 @@ class snv_indel_processor(logger):
     def construct_whizbam_links(self, df, whizbam_url):
         if not df.empty:
             self.logger.debug("--- adding Whizbam links ---")
-            df['whizbam'] = whizbam_url + "&chr=" + df['Chromosome'].str.replace("chr", "") + "&chrloc=" + df['Start_Position'].astype(str) + "-" + df['End_Position'].astype(str)
+            df['whizbam'] = whizbam_url + "&chr=" + df['Chromosome'].astype(str).str.replace("chr", "") + "&chrloc=" + df['Start_Position'].astype(str) + "-" + df['End_Position'].astype(str)
         else:
             self.logger.debug("--- No Whizbam links added to empty file ---")
         


### PR DESCRIPTION
Added a quick fix for cases where the chromosome column in the input maf file doesn't include the prefix chr and only numeric chromosomes survive filtering. Pandas was reading these entries in as numeric, instead of string, causing an error when concatenating with other strings.

Described issue here: https://github.com/oicr-gsi/djerba/issues/575