### PR TITLE
Run sample plugin for RUO to always generates the required sample_qcs…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.11.0: 2025-07-30
 - GCGI-1624: Reinstate version numbers and HRD max coverage threshold for Illumina v1.3
 - GCGI-1627: Remove obsolete 'INI schema' code
+- GCGI-1628: Run sample plugin for RUO to avoid downstream failures in the genomic_landscape.
 
 ## v1.10.2: 2025-07-22
 - GCGI-1624: Revert version numbers to Illumina v1.2, pipeline 5.0 for Djerba v1.10.2 release

--- a/src/lib/djerba/plugins/sample/plugin.py
+++ b/src/lib/djerba/plugins/sample/plugin.py
@@ -40,7 +40,7 @@ class main(plugin_base):
         ]
         for key in discovered:
             self.add_ini_discovered(key)
-        self.set_ini_default(core_constants.ATTRIBUTES, 'clinical')
+
         
         # Default parameters for priorities
         self.set_ini_default('configure_priority', 100)


### PR DESCRIPTION
The erroroccurs because the `genomic_landscape` plugin depends on the **sample_qcs.json** file, which is generated by the `sample` plugin
However, the sample plugin was hardcoded to only run when **attributes = clinical** and so for RUO the sample plugin would not run, the necessary sample_qcs.json file was never created, and the downstream genomic_landscape plugin would fail when it tried to read a missing file

Changes are made to bitbucket and the tests PASS 
```
..
----------------------------------------------------------------------
Ran 2 tests in 0.122s

OK
```