### PR TITLE
Reworking actionable fusion treatment option section

### DIFF
--- a/src/lib/djerba/mergers/treatment_options_merger/factory.py
+++ b/src/lib/djerba/mergers/treatment_options_merger/factory.py
@@ -12,12 +12,19 @@ class factory(factory_base):
     def get_json(self, **kwargs):
         try:
             gene = kwargs['gene']
+
+            # Check if gene is a fusion (contains "::")
+            if "::" in gene:
+                gene_url = "NA" # We do not need gene_url for fusions
+            else:
+                gene_url = html_builder.build_gene_url(gene)
+
             result = {
                 merger.TIER: kwargs['tier'],
                 merger.ONCOKB_LEVEL: kwargs['level'],
                 merger.TREATMENTS: kwargs['treatments'],
                 merger.GENE: gene,
-                merger.GENE_URL: html_builder.build_gene_url(gene),
+                merger.GENE_URL: gene_url,
                 merger.ALTERATION: kwargs['alteration'],
                 merger.ALTERATION_URL: kwargs['alteration_url']
             }

--- a/src/lib/djerba/mergers/treatment_options_merger/treatment_options_template.html
+++ b/src/lib/djerba/mergers/treatment_options_merger/treatment_options_template.html
@@ -26,8 +26,20 @@ ${html_builder.section_cells_begin("Treatment Options", True)}
 		<tr style="text-align:left;">
 			<td width="1%">${oncokb.oncokb_level_to_html(row[merger.ONCOKB_LEVEL])}</td>
 			<td width="59%">${row[merger.TREATMENTS]}</td>
-			<td style="font-style: italic;" width="20%">${merger.get_link(row[merger.GENE_URL], row[merger.GENE])}</td>
-			<td width="20%">${merger.get_link(row[merger.ALTERATION_URL], row[merger.ALTERATION])}</td>
+			<td style="font-style: italic;" width="20%">
+				% if "::" in row[merger.GENE]:
+					${row[merger.ALTERATION_URL]}
+				% else:
+					${merger.get_link(row[merger.GENE_URL], row[merger.GENE])}
+				% endif
+			</td>
+			<td width="20%">
+				% if "::" in row[merger.GENE]:
+					${row[merger.ALTERATION]}
+				% else:
+					${merger.get_link(row[merger.ALTERATION_URL], row[merger.ALTERATION])}
+				% endif
+			</td>
 		</tr>
 		% endfor
 		</tbody>
@@ -50,8 +62,20 @@ ${html_builder.section_cells_begin("Treatment Options", True)}
 		<tr style="text-align:left;">
 			<td width="1%">${oncokb.oncokb_level_to_html(row[merger.ONCOKB_LEVEL])}</td>
 			<td width="59%">${row[merger.TREATMENTS]}</td>
-			<td style="font-style: italic;" width="20%">${merger.get_link(row[merger.GENE_URL], row[merger.GENE])}</td>
-			<td width="20%">${merger.get_link(row[merger.ALTERATION_URL], row[merger.ALTERATION])}</td>
+			<td style="font-style: italic;" width="20%">
+				% if "::" in row[merger.GENE]:
+					${row[merger.ALTERATION_URL]}
+				% else:
+					${merger.get_link(row[merger.GENE_URL], row[merger.GENE])}
+				% endif
+			</td>
+			<td width="20%">
+				% if "::" in row[merger.GENE]:
+					${row[merger.ALTERATION]}
+				% else:
+					${merger.get_link(row[merger.ALTERATION_URL], row[merger.ALTERATION])}
+				% endif
+			</td>
 		</tr>
 		% endfor
 		</tbody>

--- a/src/lib/djerba/plugins/fusion/tools.py
+++ b/src/lib/djerba/plugins/fusion/tools.py
@@ -227,7 +227,7 @@ class fusion_tools(logger):
         """Make an entry for the treatment options merger"""
         # TODO fix the treatment options merger to display 2 genes for fusions
         genes = fusion.get_genes()
-        gene = genes[0]
+        gene = '::'.join(genes)
         factory = tom_factory(self.log_level, self.log_path)
         entries = []
         for level in therapies.keys():
@@ -237,7 +237,7 @@ class fusion_tools(logger):
                 treatments=therapies[level],
                 gene=gene,
                 alteration='Fusion',
-                alteration_url=hb.build_fusion_url(genes, oncotree_code.lower())
+                alteration_url=fusion.get_oncokb_link(oncotree_code.lower())
             )
             entries.append(entry)
         return entries


### PR DESCRIPTION
Reworked fusion treatment option section format: 
1. Added two genes to the "Gene(s)" column with corresponding links attached.
2. Removed the link attached to "Alteration" column.