### PR TITLE
Deleting-benchmark-and-report-diff-from-setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,6 @@ setup(
     name='djerba',
     version=__version__,
     scripts=[
-        'src/bin/benchmark.py',
-        'src/bin/diff_reports.py',
         'src/bin/djerba.py',
         'src/bin/generate_ini.py',
         'src/bin/mini_djerba.py',


### PR DESCRIPTION
Delete benchmark.py and report_diff.py from setup.py