### PR TITLE
Djerba setup.py update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,6 @@ setup(
     name='djerba',
     version=__version__,
     scripts=[
-        'src/bin/benchmark.py',
-        'src/bin/diff_reports.py',
         'src/bin/djerba.py',
         'src/bin/generate_ini.py',
         'src/bin/mini_djerba.py',


### PR DESCRIPTION
Removing benchmark.py and diff_reports.py from setup.py, as the benchmark plugin was removed from djerba main code.