### PR TITLE
Remove date from footer and adjust wording in Case Overview

### DIFF
--- a/src/lib/djerba/core/render.py
+++ b/src/lib/djerba/core/render.py
@@ -87,7 +87,7 @@ class html_renderer(logger):
 
     def get_page_footer(self, doc_type):
         if doc_type == cc.CLINICAL:
-            pdf_footer = "{0} - {1}".format(get_todays_date(), self.report_id)
+            pdf_footer = "{0} ".format(self.report_id)
         elif doc_type == cc.RESEARCH:
             pdf_footer = 'For Research Use Only'
         else:

--- a/src/lib/djerba/plugins/case_overview/case_overview_template.html
+++ b/src/lib/djerba/plugins/case_overview/case_overview_template.html
@@ -48,7 +48,7 @@
 	<td width="36%">${results.get(case_overview.BLOOD_SAMPLE_ID)}</td>
       </tr>
       <tr>
-	<td width="24%">Date of Report:</td>
+	<td width="24%">Date Report Prepared:</td>
 	<td width="13%">${get_todays_date()}</td>
 	<td width="20%">Report ID:</td>
 	<td width="36%">${results.get(core_constants.REPORT_ID)}</td>

--- a/src/lib/djerba/plugins/case_overview/test/plugin_test.py
+++ b/src/lib/djerba/plugins/case_overview/test/plugin_test.py
@@ -32,7 +32,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_WGTS.ini',
             self.JSON: json_location,
-            self.MD5: 'de40b030750867c6a70c1f498bc8645b'
+            self.MD5: '0e8a60071d2af9c60c35397e6e07fc2e'
         }
         self.run_basic_test(test_source_dir, params)
 
@@ -42,7 +42,7 @@ class TestCaseOverview(PluginTester):
         params = {
             self.INI: 'case_overview_TAR.ini',
             self.JSON: json_location,
-            self.MD5: '22b3671964076207828e8030c7e395a7'
+            self.MD5: '160a9b63e1a83d7416cb3e6062e9b6ae'
         }
         self.run_basic_test(test_source_dir, params)
 


### PR DESCRIPTION
1. Remove date from page footers.
2. Change "Date of Report" to "Date Report Prepared" in the Case Overview section.
3. Update MD5 value of Case Overview plugin tests