### PR TITLE
Update python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- GCGI-1662: Update Python dependency to 3.13.0 or greater
+
 ## v1.11.6: 2026-02-04
 - GCGI-1596: Fix to allow `--log-path` command-line option to work
 - GCGI-1671: Fixes for outdated OncoKB test data. Adds DJERBA_TEST_OUTPUT_DIR hook.

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         'seaborn',
         'statsmodels',
     ],
-    python_requires='>=3.10.6',
+    python_requires='>=3.13.0',
     author="Iain Bancarz",
     author_email="ibancarz [at] oicr [dot] on [dot] ca",
     description="Create reports from metadata and workflow output",


### PR DESCRIPTION
After this PR is merged, any build from the release branch will require Python >= 3.13.0.
The Modulator YAML will need to be updated accordingly.