### PR TITLE
GCGI-1705: TAR swgs showing CNVs even though TF < 10%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- CGCI-1705: Write the ichorCNA purity in decimal instead of percentage format into purity.txt 
+
 ## v1.11.10: 2026-04-01
 - GCGI-1697: Compute major and minor allele copy numbers internally due to their removal in Purple v4.3+ from the segments output file.
 - GCGI-1691: Moved TAR QCs from taking from the consensusCruncher hsmetrics file to taking form the umiconsensus cache

--- a/src/lib/djerba/plugins/tar/sample/plugin.py
+++ b/src/lib/djerba/plugins/tar/sample/plugin.py
@@ -91,8 +91,8 @@ class main(plugin_base):
 
             # Round and clean purity for report aesthetic
             # If purity is <10%, only report as <10% (not exact number)
-            purity = round(purity*100, 1)
             self.write_purity(purity, work_dir)
+            purity = round(purity*100, 1)
             if purity < 10:
                 purity = "<10"
 


### PR DESCRIPTION
Write the ichorCNA purity as the decimal instead of percentage format into purity.txt.