### PR TITLE
- Split patient name into separate last name / first name rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## UNRELEASED 
+- GCGI-1736: Patient & Physician report header improvements.
+
 ## v1.11.12: 2026-06-01
 - GCGI-1708: Separate patient and physician information into two distinct sections and update the director contact details.
 - GCGI-1712: Update main contact name in clinical report header

--- a/src/lib/djerba/plugins/patient_info/patient_info_template.html
+++ b/src/lib/djerba/plugins/patient_info/patient_info_template.html
@@ -1,5 +1,12 @@
 <%
   from djerba.plugins.patient_info.plugin import main as plugin
+
+  full_name = results.get(plugin.PATIENT_NAME) or ''
+  if ',' in full_name:
+      patient_last_name, patient_first_name = [p.strip() for p in full_name.split(',', 1)]
+  else:
+      patient_last_name = full_name.strip()
+      patient_first_name = ''
 %>
 
 <!-- Patient & Physician -->
@@ -22,7 +29,7 @@
           <h3>Patient Information</h3>
         </td>
 
-        <td style="width:160px;"></td>
+        <td style="width:120px;"></td>
 
         <td colspan="2">
           <h3>Physician Information</h3>
@@ -32,11 +39,11 @@
       <!-- Row 1 -->
       <tr>
         <td style="font-weight:bold; padding-right:6px; white-space:nowrap;">
-          Name:
+          Last Name:
         </td>
 
         <td style="font-weight:normal; white-space:nowrap;">
-          ${results.get(plugin.PATIENT_NAME)}
+          ${patient_last_name}
         </td>
 
         <td></td>
@@ -53,11 +60,11 @@
       <!-- Row 2 -->
       <tr>
         <td style="font-weight:bold; padding-right:6px; white-space:nowrap;">
-          Sex At Birth:
+          First Name:
         </td>
 
         <td style="font-weight:normal; white-space:nowrap;">
-          ${results.get(plugin.PATIENT_SEX)}
+          ${patient_first_name}
         </td>
 
         <td></td>
@@ -74,11 +81,11 @@
       <!-- Row 3 -->
       <tr>
         <td style="font-weight:bold; padding-right:6px; white-space:nowrap;">
-          DOB:
+          Sex At Birth:
         </td>
 
         <td style="font-weight:normal; white-space:nowrap;">
-          ${results.get(plugin.PATIENT_DOB)}
+          ${results.get(plugin.PATIENT_SEX)}
         </td>
 
         <td></td>
@@ -92,12 +99,14 @@
         </td>
       </tr>
 
-      <!-- Row 4: Requisitioner Header + Physician Phone -->
+      <!-- Row 4 -->
       <tr>
-        <td colspan="2">
-          <h3 style="margin:0;">
-            Requisitioner Information
-          </h3>
+        <td style="font-weight:bold; padding-right:6px; white-space:nowrap;">
+          Date of Birth:
+        </td>
+
+        <td style="font-weight:normal; white-space:nowrap;">
+          ${results.get(plugin.PATIENT_DOB)}
         </td>
 
         <td></td>
@@ -111,16 +120,17 @@
         </td>
       </tr>
 
-      <!-- Row 5: Requisitioner Email -->
+      <!-- Row 5 -->
       <tr>
-        <td style="font-weight:bold; padding-right:6px;">
-          Email:
-        </td>
+        <td></td>
 
-        <td colspan="4" style="font-weight:normal;">
-          <a href="mailto:${results.get(plugin.REQ_EMAIL)}">
-            ${results.get(plugin.REQ_EMAIL)}
-          </a>
+        <td></td>
+
+        <td></td>
+
+        <td colspan="2" style="font-weight:normal;">
+          <span style="font-weight:bold; padding-right:6px; white-space:nowrap;">Requisitioner Email:</span>
+          <a href="mailto:${results.get(plugin.REQ_EMAIL)}">${results.get(plugin.REQ_EMAIL)}</a>
         </td>
       </tr>
 

--- a/src/lib/djerba/plugins/patient_info/test/plugin_test.py
+++ b/src/lib/djerba/plugins/patient_info/test/plugin_test.py
@@ -18,7 +18,7 @@ class TestPatientInfo(PluginTester):
         params = {
             self.INI: 'patient_info.ini',
             self.JSON: 'patient_info.json',
-            self.MD5: 'cc55c245bbb000dd85b598203d4e15b1'
+            self.MD5: 'eaa6439bfdab4f9950f92b8bb5b3f246'
         }
         self.run_basic_test(test_source_dir, params)
 

--- a/src/test/core/test_core.py
+++ b/src/test/core/test_core.py
@@ -725,7 +725,7 @@ class TestMainScript(TestCore):
         html_path = os.path.join(self.tmp_dir, 'placeholder_report.clinical.html')
         with open(html_path) as html_file:
             html_string = html_file.read()
-        self.assert_report_MD5(html_string, '0382f1356ba06550a8062d68b065996c')
+        self.assert_report_MD5(html_string, '39d1d200f8f41d8219164d16b7322610')
         pdf_path = os.path.join(self.tmp_dir, 'placeholder_report.clinical.pdf')
         self.assertTrue(os.path.isfile(pdf_path))
         updated_path = os.path.join(self.tmp_dir, 'simple_report_for_update.updated.json')


### PR DESCRIPTION
- Spell out DOB
- Move requisitioner email into the physician information column
- Shift physician column left so long hospital names don't overflowing the margin
- Update checksums
- Update changelog