### PR TITLE
Dev gcgi 1748 gene id warning fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 - GCGI-1753: Updated Djerba expression processing to use TPM based values instead of FPKM.
-
+- GCGI-1748: Make gene ID warnings less verbose
 
 ## v1.12.0: 2026-07-06
 - GCGI-1709: Update title of research report and add watermark to the pdf.

--- a/src/lib/djerba/helpers/expression_helper/helper.py
+++ b/src/lib/djerba/helpers/expression_helper/helper.py
@@ -130,11 +130,12 @@ class main(helper_base):
             # preprocess the GEP file
             reader = csv.reader(in_file, delimiter="\t")
             writer = csv.writer(out_file, delimiter="\t")
-            first = True
+            not_found = 0
+            total = 0
             for row in reader:
-                if first:
+                total += 1
+                if total == 1:
                     row.insert(1, tumour_id)
-                    first = False
                 else:
                     # Skip ensembl IDs with "_PAR_Y" suffix and remove version numbers in reference file
                     gene_id_full = row[0]
@@ -148,9 +149,15 @@ class main(helper_base):
                     except KeyError as err:
                         msg = 'Reference gene ID {0} from {1} '.format(gene_id_full, ref_path) +\
                             'not found in gep results path {0}'.format(gep_path)
-                        self.logger.warn(msg)
+                        self.logger.debug(msg)
                         row.insert(1, '0.0')
+                        not_found += 1
                 writer.writerow(row)
+            if not_found>0:
+                msg = '{0} of {1} reference gene IDs from {2} '.format(not_found, total, ref_path) +\
+                    'not found in gep results path {0}. '.format(gep_path) +\
+                    'Run with --debug for details.'
+                self.logger.warning(msg)
         return self.workspace.abs_path(out_file_name)
 
     def specify_params(self):

--- a/src/lib/djerba/helpers/expression_helper/test/helper_test.py
+++ b/src/lib/djerba/helpers/expression_helper/test/helper_test.py
@@ -74,11 +74,11 @@ class TestExpressionHelper(TestBase):
         gep_path = ws.abs_path('gep.txt')
         self.assertEqual(self.getMD5(gep_path), '9155adcfa33ae7b6e2c0034148b383cf')
         expected = {
-            'data_expression_percentile_comparison.txt': 'b80bff26dfe4996b9dab2a1dbdc727be',
-            'data_expression_percentile_tcga.txt': 'e820ef9a2d005feefa92887d6728180b',
-            'data_expression_zscores_comparison.txt': '406d32739e9c61f490d67005d914babc',
-            'data_expression_zscores_tcga.txt': '4d646d0fa4065d12c9c97e3b38f8896e',
-            'data_expression_percentile_tcga.json': '68379be6cd9b6cfdc27972ee03738b26'
+            'data_expression_percentile_comparison.txt': 'a213ab260cefbe28fd504c8b70c28738',
+            'data_expression_percentile_tcga.txt': '4d6e45e47a28cff3e6fc179ccc9ec967',
+            'data_expression_zscores_comparison.txt': 'ae56589f46a74ad5a16aecfe919371bb',
+            'data_expression_zscores_tcga.txt': '98321a05f21035a08524dbb92b829a38',
+            'data_expression_percentile_tcga.json': 'ab1671a9774c1fcc67da4a9cb063bf01'
         }
         for name in expected:
             out_path = os.path.join(self.tmp_dir, name)
@@ -109,11 +109,11 @@ class TestExpressionHelper(TestBase):
         gep_path = ws.abs_path('gep.txt')
         self.assertEqual(self.getMD5(gep_path), '9155adcfa33ae7b6e2c0034148b383cf')
         expected = {
-            'data_expression_percentile_comparison.txt': 'b80bff26dfe4996b9dab2a1dbdc727be',
-            'data_expression_percentile_tcga.txt': '35781f07b63bc72470610f27c105f9cb',
-            'data_expression_zscores_comparison.txt': '406d32739e9c61f490d67005d914babc',
-            'data_expression_zscores_tcga.txt': '912a5a7fc4cf3da67676ae440920e807',
-            'data_expression_percentile_tcga.json': '3bc60aeb284205418e3f8d27b92f9a88'
+            'data_expression_percentile_comparison.txt': 'a213ab260cefbe28fd504c8b70c28738',
+            'data_expression_percentile_tcga.txt': 'bc27d32071fdae27f150e0692fca7b27',
+            'data_expression_zscores_comparison.txt': 'ae56589f46a74ad5a16aecfe919371bb',
+            'data_expression_zscores_tcga.txt': 'e3ad7a1eadeb1115836723edd3bcd8c0',
+            'data_expression_percentile_tcga.json': '94d30b027047935960c9a82042e571fd'
         }
         for name in expected:
             out_path = os.path.join(self.tmp_dir, name)


### PR DESCRIPTION
Warnings now look like:
`2026-07-17_14:47:26 djerba:expression_helper WARNING: 297 of 60604 reference gene IDs from /.mounts/labs/CGI/gsi/tools/djerba/gep_reference.txt.gz not found in gep results path /.mounts/labs/prod/vidarr/output-clinical/f795/f045/0e6d/f795f0450e6d91f4dcce526c4311b39c2c649cfa099aa2d162a506945f760ec8/VNWGTS_0797_Pe_M_WT_RB-3095.genes.results. Run with --debug for details.`