### PR TITLE
Fix mislabeled renal rows in tcga_code_key.txt

### DIFF
--- a/src/lib/djerba/helpers/input_params_helper/tcga_code_key.txt
+++ b/src/lib/djerba/helpers/input_params_helper/tcga_code_key.txt
@@ -17,9 +17,9 @@ MBN	dlbc	Neoplasm Diffuse Large B-cell Lymphoma	Lymphoid	37
 ESCA	esca	Esophageal Carcinoma	Esophagus/Stomach	182
 GBM	gbm	Glioblastoma Multiforme	Brain	87
 HNSC	hnsc	Head and Neck Squamous Cell Carcinoma	Head and Neck	502
-RCC	kich	Kidney Chromophobe	Kidney	65
-CCSK	kirc	Kidney Renal Clear Cell Carcinoma	Kidney	356
-RCC	kirp	Kidney Renal Papillary Cell Carcinoma	Kidney	274
+CHRCC	kich	Kidney Chromophobe	Kidney	65
+CCRCC	kirc	Kidney Renal Clear Cell Carcinoma	Kidney	356
+PRCC	kirp	Kidney Renal Papillary Cell Carcinoma	Kidney	274
 AML	laml	Acute Myeloid Leukemia	Myeloid	199
 ENCG	lgg	Lower Grade Glioma	Brain	510
 HCC	lihc	Hepatocellular Carcinoma	"Biliary Tract,Liver"	358


### PR DESCRIPTION
Fixes #671

This PR fixes the mislabeled renal rows in tcga_code_key.txt.

- CCSK maps to kirc, but in the bundled OncoTree data CCSK is Clear Cell Sarcoma of Kidney, not clear cell renal cell carcinoma (CCRCC).

- kich and kirp are associated with the broader RCC code rather than CHRCC and PRCC.

- RCC therefore appears twice, although convert_oncotree_to_tcga() states the file should contain no duplicate OncoTree codes; a lookup of RCC returns a Series and raises on .upper().

This relabels the three rows to CHRCC, CCRCC and PRCC. Existing tests pass unchanged.