### PR TITLE
Feature/tcga code fallback

### DIFF
--- a/src/lib/djerba/helpers/input_params_helper/helper.py
+++ b/src/lib/djerba/helpers/input_params_helper/helper.py
@@ -1,9 +1,11 @@
 import os
 import csv
 import gzip
+import json
 import logging
 import pandas as pd
 import djerba.core.constants as core_constants
+import djerba.plugins.genomic_landscape as genomic_landscape
 from djerba.util.environment import directory_finder
 import djerba.util.ini_fields as ini  # TODO new module for these constants?
 import djerba.util.provenance_index as index
@@ -43,6 +45,21 @@ class main(helper_base):
     NA = "NA"
     TCGA_DEFAULT = "TCGA_ALL_TUMOR"
     TCGA_CODE_KEY = "tcga_code_key.txt"
+    PRIMARY_SITE = "primary_site"
+    ONCOTREE_FILE = "OncoTree.json"
+
+    # OncoTree tissue names that differ from the primary_site column in tcga_code_key.txt
+    TISSUE_TO_SITE = {
+        "CNS/Brain": "Brain",
+        "Ovary/Fallopian Tube": "Ovary",
+        "Cervix": "Cervix,Uterus",
+        "Uterus": "Cervix,Uterus",
+        "Biliary Tract": "Biliary Tract,Liver",
+        "Liver": "Biliary Tract,Liver",  # liver maps to the hepatobiliary cohort, not the pancreatic one
+        "Pancreas": "Pancreas, Liver",
+        "Peritoneum": "Peritoneum,Pleura",
+        "Pleura": "Peritoneum,Pleura",
+    }
 
     VERSION = "1.0.0"
 
@@ -163,22 +180,60 @@ class main(helper_base):
             raise ValueError(msg)
 
     def convert_oncotree_to_tcga(self, oncotree_code):
-        
-        # Read tcga_code_key.txt as a database
+
         plugin_dir = os.path.dirname(os.path.realpath(__file__))
         df = pd.read_csv(os.path.join(plugin_dir, self.TCGA_CODE_KEY), sep = "\t", index_col = self.ONCOTREE_CODE)
+        code = oncotree_code.upper()
 
-        # Lookup oncotree_code in the dataframe and get the corresponding tcga_code
-        # Note: the data in the text file should contain no duplicate oncotree code values.
-        # If error occurs (i.e. could not find oncotree_code in table), default to TCGA_ALL_TUMOR with a warning.
-        try:
-            tcga_code = df.loc[oncotree_code.upper(), self.TCGA_CODE]
-        except:
-            tcga_code = self.TCGA_DEFAULT
-            msg = "Could not find ONCOTREE code {0} in tcga_code_key.txt. Defaulting to {1}. If you know the correct corresponding TCGA code, please manually specify it.".format(oncotree_code, self.TCGA_DEFAULT)
-            self.logger.warning(msg)
+        # Direct lookup in tcga_code_key.txt
+        if code in df.index:
+            return self._join_tcga_codes(df.loc[df.index == code, self.TCGA_CODE])
 
-        return tcga_code.upper()
+        oncotree_map = self._build_oncotree_map()
+
+        # Walk OncoTree ancestors and use the nearest one present in the table
+        current = code
+        seen = set()
+        while current in oncotree_map and current not in seen:
+            seen.add(current)
+            parent = oncotree_map[current].get("parent")
+            if not parent or parent == "TISSUE":
+                break
+            if parent in df.index:
+                return self._join_tcga_codes(df.loc[df.index == parent, self.TCGA_CODE])
+            current = parent
+
+        # Fall back to every cohort sharing the same tissue
+        node = oncotree_map.get(code)
+        tissue = node.get("tissue") if node else None
+        if tissue:
+            site = self.TISSUE_TO_SITE.get(tissue, tissue)
+            matches = df[df[self.PRIMARY_SITE] == site]
+            if len(matches) > 0:
+                return self._join_tcga_codes(matches[self.TCGA_CODE])
+
+        msg = "Could not find ONCOTREE code {0} in tcga_code_key.txt. Defaulting to {1}. If you know the correct corresponding TCGA code, please manually specify it.".format(oncotree_code, self.TCGA_DEFAULT)
+        self.logger.warning(msg)
+        return self.TCGA_DEFAULT
+
+    def _build_oncotree_map(self):
+        data_dir = os.path.dirname(genomic_landscape.__file__)
+        json_path = os.path.join(data_dir, "data", self.ONCOTREE_FILE)
+        with open(json_path) as in_file:
+            data = json.load(in_file)
+        oncotree_map = {}
+        nodes = [data["TISSUE"]]
+        while nodes:
+            node = nodes.pop()
+            code = node.get("code")
+            if code and code != "TISSUE":
+                oncotree_map[code] = {"parent": node.get("parent"), "tissue": node.get("tissue")}
+            for child in (node.get("children") or {}).values():
+                nodes.append(child)
+        return oncotree_map
+
+    def _join_tcga_codes(self, tcga_codes):
+        return "|".join(sorted(tcga_codes.str.upper().unique()))
 
 
     def write_input_params_info(self, input_params_info):

--- a/src/lib/djerba/helpers/input_params_helper/test/helper_ancestor.ini
+++ b/src/lib/djerba/helpers/input_params_helper/test/helper_ancestor.ini
@@ -1,0 +1,14 @@
+[core]
+
+[input_params_helper]
+donor=PLACEHOLDER
+project=PLACEHOLDER
+study=PLACEHOLDER
+# AMLNPM1 is not in the table, its ancestor AML is
+oncotree_code=AMLNPM1
+primary_cancer=Pancreatic adenocarcinoma
+site_of_biopsy=Liver
+requisition_approved=2023-03-28
+assay=WGTS
+requisition_id=PLACEHOLDER
+sample_type=FFPE

--- a/src/lib/djerba/helpers/input_params_helper/test/helper_renal_subtype.ini
+++ b/src/lib/djerba/helpers/input_params_helper/test/helper_renal_subtype.ini
@@ -1,0 +1,14 @@
+[core]
+
+[input_params_helper]
+donor=PLACEHOLDER
+project=PLACEHOLDER
+study=PLACEHOLDER
+# CCRCC is a renal subtype, resolved by a direct lookup to KIRC
+oncotree_code=CCRCC
+primary_cancer=Pancreatic adenocarcinoma
+site_of_biopsy=Liver
+requisition_approved=2023-03-28
+assay=WGTS
+requisition_id=PLACEHOLDER
+sample_type=FFPE

--- a/src/lib/djerba/helpers/input_params_helper/test/helper_test.py
+++ b/src/lib/djerba/helpers/input_params_helper/test/helper_test.py
@@ -6,7 +6,9 @@ Test of the input params helper
 
 import logging
 import os
+import pandas as pd
 import unittest
+import djerba.helpers.input_params_helper.helper as input_params_helper
 from configparser import ConfigParser
 from shutil import copy
 from djerba.core.loaders import helper_loader
@@ -19,6 +21,9 @@ class InputParamsHelper(TestBase):
     HELPER_NAME = 'input_params_helper'
     INPUT_PARAMS_MD5 = '21fecd82ee6be1615db6770d7d32a618'
     INPUT_PARAMS_MD5_UNKNOWN_ONCO = '8e0c3c4688865c897c18ef985194c9ca'
+    INPUT_PARAMS_MD5_ANCESTOR = '37731eb6f0b4bdc8e58aa7f587b18771'
+    INPUT_PARAMS_MD5_TISSUE = '48bde2b96e73a82d1ca538d34d36a6eb'
+    INPUT_PARAMS_MD5_RENAL_SUBTYPE = '3801bda398c3b7742caf633cf1801aa9'
 
 
     def testExtract(self):
@@ -110,6 +115,110 @@ class InputParamsHelper(TestBase):
 
         # Compare it against the md5 of the expected input_params.json
         self.assertEqual(self.getMD5(input_params_path), self.INPUT_PARAMS_MD5_UNKNOWN_ONCO)
+
+
+    def testExtractAncestorOncotreeCode(self):
+        """
+        Output will be a lookup of the nearest OncoTree ancestor, AML, yielding LAML.
+        """
+        test_source_dir = os.path.realpath(os.path.dirname(__file__))
+
+        # Get the config
+        cp = ConfigParser()
+        cp.read(os.path.join(test_source_dir, 'helper_ancestor.ini'))
+
+        loader = helper_loader(logging.WARNING)
+
+        # Get the workspace
+        ws = workspace(self.tmp_dir)
+
+        helper_main = loader.load(self.HELPER_NAME, ws)
+
+        # Run configure step
+        helper_main.configure(cp)
+
+        # Get the input_params.json path that was just generated
+        input_params_path = os.path.join(self.tmp_dir, 'input_params.json')
+
+        # Check if the input_params.json path exists
+        self.assertTrue(os.path.exists(input_params_path))
+
+        # Compare it against the md5 of the expected input_params.json
+        self.assertEqual(self.getMD5(input_params_path), self.INPUT_PARAMS_MD5_ANCESTOR)
+
+
+    def testExtractTissueOncotreeCode(self):
+        """
+        Output will fall back to the lung cohorts, yielding LUAD|LUSC.
+        """
+        test_source_dir = os.path.realpath(os.path.dirname(__file__))
+
+        # Get the config
+        cp = ConfigParser()
+        cp.read(os.path.join(test_source_dir, 'helper_tissue.ini'))
+
+        loader = helper_loader(logging.WARNING)
+
+        # Get the workspace
+        ws = workspace(self.tmp_dir)
+
+        helper_main = loader.load(self.HELPER_NAME, ws)
+
+        # Run configure step
+        helper_main.configure(cp)
+
+        # Get the input_params.json path that was just generated
+        input_params_path = os.path.join(self.tmp_dir, 'input_params.json')
+
+        # Check if the input_params.json path exists
+        self.assertTrue(os.path.exists(input_params_path))
+
+        # Compare it against the md5 of the expected input_params.json
+        self.assertEqual(self.getMD5(input_params_path), self.INPUT_PARAMS_MD5_TISSUE)
+
+
+    def testExtractRenalSubtype(self):
+        """
+        Output will be a lookup of CCRCC, yielding KIRC.
+        """
+        test_source_dir = os.path.realpath(os.path.dirname(__file__))
+
+        # Get the config
+        cp = ConfigParser()
+        cp.read(os.path.join(test_source_dir, 'helper_renal_subtype.ini'))
+
+        loader = helper_loader(logging.WARNING)
+
+        # Get the workspace
+        ws = workspace(self.tmp_dir)
+
+        helper_main = loader.load(self.HELPER_NAME, ws)
+
+        # Run configure step
+        helper_main.configure(cp)
+
+        # Get the input_params.json path that was just generated
+        input_params_path = os.path.join(self.tmp_dir, 'input_params.json')
+
+        # Check if the input_params.json path exists
+        self.assertTrue(os.path.exists(input_params_path))
+
+        # Compare it against the md5 of the expected input_params.json
+        self.assertEqual(self.getMD5(input_params_path), self.INPUT_PARAMS_MD5_RENAL_SUBTYPE)
+
+
+    def testTissueToSiteMapping(self):
+        """
+        Every primary site in the tissue mapping must be present in tcga_code_key.txt.
+        """
+        helper_class = input_params_helper.main
+        helper_dir = os.path.dirname(os.path.realpath(input_params_helper.__file__))
+        df = pd.read_csv(os.path.join(helper_dir, helper_class.TCGA_CODE_KEY), sep = "\t")
+        sites = set(df[helper_class.PRIMARY_SITE])
+
+        # An unmatched site would silently fall back to TCGA_ALL_TUMOR
+        for tissue, site in helper_class.TISSUE_TO_SITE.items():
+            self.assertIn(site, sites, tissue)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/lib/djerba/helpers/input_params_helper/test/helper_tissue.ini
+++ b/src/lib/djerba/helpers/input_params_helper/test/helper_tissue.ini
@@ -1,0 +1,14 @@
+[core]
+
+[input_params_helper]
+donor=PLACEHOLDER
+project=PLACEHOLDER
+study=PLACEHOLDER
+# ALUCA has no ancestor in the table, falls back to tissue
+oncotree_code=ALUCA
+primary_cancer=Pancreatic adenocarcinoma
+site_of_biopsy=Liver
+requisition_approved=2023-03-28
+assay=WGTS
+requisition_id=PLACEHOLDER
+sample_type=FFPE

--- a/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
+++ b/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
@@ -40,7 +40,8 @@ if(biomarker=="tmb"){
   tcga_tmb_data_type <- tcga_tmb_data %>% filter(CANCER.TYPE %in% codes)
   
   
-  if (nrow(external_tmb_data_type) > 0){
+  # the external data covers one cancer type, so it does not apply to merged codes
+  if (length(codes) == 1 && nrow(external_tmb_data_type) > 0){
     median_tmb <- median(external_tmb_data_type$tmb)
     cohort_label <- paste(tcga_label ,"Cohort")
   }
@@ -59,7 +60,7 @@ if(biomarker=="tmb"){
   print(
   ggplot(tcga_tmb_data) + 
     {
-      if (nrow(external_tmb_data_type) > 0)
+      if (length(codes) == 1 && nrow(external_tmb_data_type) > 0)
         geom_boxplot(data = external_tmb_data_type, aes(x=0,y=tmb,color="Cohort"),width = 0.1, outlier.shape = NA) 
         
       else if (nrow(tcga_tmb_data_type) > 0)

--- a/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
+++ b/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
@@ -31,19 +31,22 @@ if(biomarker=="tmb"){
   tcga_tmb_file <- paste(data_dir, 'tmbcomp-tcga.txt', sep='/')
   tcga_tmb_data <- read.delim(tcga_tmb_file, header = TRUE, stringsAsFactors = F)
   
+  # tcga_code may be several merged codes joined by '|'
+  codes <- unlist(strsplit(sample_tcga, "\\|"))
+  tcga_label <- paste(toupper(codes), collapse="/")
   #subset external data to cancer type
-  external_tmb_data_type <- external_tmb_data %>% filter(if (sample_tcga %in% external_tmb_data$CANCER.TYPE) CANCER.TYPE == sample_tcga else NA)
+  external_tmb_data_type <- external_tmb_data %>% filter(CANCER.TYPE %in% codes)
   #subset tcga data to cancer type
-  tcga_tmb_data_type <- tcga_tmb_data %>% filter(if (sample_tcga %in% tcga_tmb_data$CANCER.TYPE) CANCER.TYPE == sample_tcga else NA)
+  tcga_tmb_data_type <- tcga_tmb_data %>% filter(CANCER.TYPE %in% codes)
   
   
-  if (sample_tcga %in% external_tmb_data_type$CANCER.TYPE){
+  if (nrow(external_tmb_data_type) > 0){
     median_tmb <- median(external_tmb_data_type$tmb)
-    cohort_label <- paste(toupper(sample_tcga) ,"Cohort")
+    cohort_label <- paste(tcga_label ,"Cohort")
   }
-  else if (sample_tcga %in% tcga_tmb_data_type$CANCER.TYPE){
+  else if (nrow(tcga_tmb_data_type) > 0){
     median_tmb <- median(tcga_tmb_data_type$tmb)
-    cohort_label <- paste("TCGA",toupper(sample_tcga),"Cohort")
+    cohort_label <- paste("TCGA",tcga_label,"Cohort")
   }
   else{
     median_tmb <- median(tcga_tmb_data$tmb)
@@ -56,10 +59,10 @@ if(biomarker=="tmb"){
   print(
   ggplot(tcga_tmb_data) + 
     {
-      if (sample_tcga %in% external_tmb_data_type$CANCER.TYPE)
+      if (nrow(external_tmb_data_type) > 0)
         geom_boxplot(data = external_tmb_data_type, aes(x=0,y=tmb,color="Cohort"),width = 0.1, outlier.shape = NA) 
         
-      else if (sample_tcga %in% tcga_tmb_data_type$CANCER.TYPE)
+      else if (nrow(tcga_tmb_data_type) > 0)
         geom_boxplot(data = tcga_tmb_data_type, aes(x=0,y=tmb,color="Cohort"), width = 0.1, outlier.shape = NA) 
       else
         geom_boxplot(aes(x=0,y=tmb,color="All TCGA"),width = 0.1, outlier.shape = NA) 

--- a/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
+++ b/src/lib/djerba/plugins/genomic_landscape/Rscripts/tmb_plot.R
@@ -45,7 +45,7 @@ if(biomarker=="tmb"){
     median_tmb <- median(external_tmb_data_type$tmb)
     cohort_label <- paste(tcga_label ,"Cohort")
   }
-  else if (nrow(tcga_tmb_data_type) > 0){
+  else if (all(codes %in% tcga_tmb_data$CANCER.TYPE)){
     median_tmb <- median(tcga_tmb_data_type$tmb)
     cohort_label <- paste("TCGA",tcga_label,"Cohort")
   }
@@ -63,7 +63,7 @@ if(biomarker=="tmb"){
       if (length(codes) == 1 && nrow(external_tmb_data_type) > 0)
         geom_boxplot(data = external_tmb_data_type, aes(x=0,y=tmb,color="Cohort"),width = 0.1, outlier.shape = NA) 
         
-      else if (nrow(tcga_tmb_data_type) > 0)
+      else if (all(codes %in% tcga_tmb_data$CANCER.TYPE))
         geom_boxplot(data = tcga_tmb_data_type, aes(x=0,y=tmb,color="Cohort"), width = 0.1, outlier.shape = NA) 
       else
         geom_boxplot(aes(x=0,y=tmb,color="All TCGA"),width = 0.1, outlier.shape = NA) 

--- a/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
+++ b/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
@@ -56,6 +56,10 @@ class TestGenomicLandscapePlugin(PluginTester):
         self.assertEqual(tmb.read_cohort(data_dir, "luad"), "TCGA LUAD")
         self.assertEqual(tmb.read_cohort(data_dir, "paad"), "COMPASS")
         self.assertEqual(tmb.read_cohort(data_dir, "zzz"), "NA")
+        # the merged percentile pools both cohorts, it does not pick one of them
+        self.assertEqual(tmb.read_cancer_specific_percentile(data_dir, 2.5, "TCGA LUAD", "luad"), 19)
+        self.assertEqual(tmb.read_cancer_specific_percentile(data_dir, 2.5, "TCGA LUSC", "lusc"), 3)
+        self.assertEqual(tmb.read_cancer_specific_percentile(data_dir, 2.5, "TCGA LUAD/LUSC", "luad|lusc"), 12)
 
     def testGenomicLandscapeLowTmbStableMsi(self):
         test_source_dir = os.path.realpath(os.path.dirname(__file__))

--- a/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
+++ b/src/lib/djerba/plugins/genomic_landscape/test/plugin_test.py
@@ -15,6 +15,7 @@ from djerba.plugins.plugin_tester import PluginTester
 from djerba.core.workspace import workspace
 from djerba.util.environment import directory_finder
 from djerba.plugins.genomic_landscape.hrd import hrd_processor
+from djerba.plugins.genomic_landscape.tmb import tmb_processor
 
 class TestGenomicLandscapePlugin(PluginTester):
     
@@ -44,6 +45,17 @@ class TestGenomicLandscapePlugin(PluginTester):
         self.assertEqual(hrd.annotate_NCCN("HR Proficient", "HGSOC", dir1, dir2), None)
         HRD_annotated = hrd.annotate_NCCN("HRD", "HGSOC", dir1, dir2)
         self.assertEqual(HRD_annotated['Tier'], "Prognostic")
+
+    def testMergedTcgaCodeCohort(self):
+        # contains the TMB comparison files
+        data_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'data'))
+        tmb = tmb_processor(log_level=logging.ERROR, log_path=None)
+        # merged codes are joined with '/' for display
+        self.assertEqual(tmb.read_cohort(data_dir, "luad|lusc"), "TCGA LUAD/LUSC")
+        # a single code is unchanged
+        self.assertEqual(tmb.read_cohort(data_dir, "luad"), "TCGA LUAD")
+        self.assertEqual(tmb.read_cohort(data_dir, "paad"), "COMPASS")
+        self.assertEqual(tmb.read_cohort(data_dir, "zzz"), "NA")
 
     def testGenomicLandscapeLowTmbStableMsi(self):
         test_source_dir = os.path.realpath(os.path.dirname(__file__))

--- a/src/lib/djerba/plugins/genomic_landscape/tmb.py
+++ b/src/lib/djerba/plugins/genomic_landscape/tmb.py
@@ -83,10 +83,11 @@ class tmb_processor(logger):
                 data_filename = constants.TMBCOMP_EXTERNAL
             else:
                 data_filename = constants.TMBCOMP_TCGA
+            codes = set(cancer_type.lower().split('|'))
             tmb_array = []
             with open(os.path.join(data_dir, data_filename)) as data_file:
                 for row in csv.DictReader(data_file, delimiter="\t"):
-                    if row[constants.CANCER_TYPE_HEADER] == cancer_type:
+                    if row[constants.CANCER_TYPE_HEADER] in codes:
                         tmb_array.append(float(row[constants.TMB_HEADER]))
             ecdf = ECDF(tmb_array)
             percentile = int(round(ecdf(tmb) * 100, 0))  # return an integer percentile
@@ -106,10 +107,11 @@ class tmb_processor(logger):
             reader = csv.reader(tcga_file, delimiter="\t")
             for row in reader:
                 tcga_cancer_types.add(row[3])
-        if tcga_code.lower() == 'paad':
+        codes = tcga_code.lower().split('|')
+        if 'paad' in codes:
             cohort = constants.COMPASS
-        elif tcga_code.lower() in tcga_cancer_types:
-            cohort = "".join(("TCGA ", tcga_code.upper()))
+        elif any(code in tcga_cancer_types for code in codes):
+            cohort = "".join(("TCGA ", tcga_code.upper().replace('|', '/')))
         else:
             cohort = constants.NA
         return cohort

--- a/src/lib/djerba/plugins/genomic_landscape/tmb.py
+++ b/src/lib/djerba/plugins/genomic_landscape/tmb.py
@@ -110,7 +110,7 @@ class tmb_processor(logger):
         codes = tcga_code.lower().split('|')
         if codes == ['paad']:
             cohort = constants.COMPASS
-        elif any(code in tcga_cancer_types for code in codes):
+        elif all(code in tcga_cancer_types for code in codes):
             cohort = "".join(("TCGA ", tcga_code.upper().replace('|', '/')))
         else:
             cohort = constants.NA

--- a/src/lib/djerba/plugins/genomic_landscape/tmb.py
+++ b/src/lib/djerba/plugins/genomic_landscape/tmb.py
@@ -108,7 +108,7 @@ class tmb_processor(logger):
             for row in reader:
                 tcga_cancer_types.add(row[3])
         codes = tcga_code.lower().split('|')
-        if 'paad' in codes:
+        if codes == ['paad']:
             cohort = constants.COMPASS
         elif any(code in tcga_cancer_types for code in codes):
             cohort = "".join(("TCGA ", tcga_code.upper().replace('|', '/')))


### PR DESCRIPTION
Find a matching TCGA cohort from OncoTree

When an OncoTree code have no direct TCGA match, djerba now uses its nearest mapped ancestor or cohorts from the same tissue before falling back to tcga_all_tumor. TMB percentiles and plots now support combined cohorts. COMPASS still applies only to paad.
